### PR TITLE
Add support for rfc6901/rfc6902

### DIFF
--- a/dom/container.go
+++ b/dom/container.go
@@ -75,6 +75,19 @@ func (c *containerImpl) Flatten() map[string]Leaf {
 	return ret
 }
 
+func (c *containerImpl) Equals(node Node) bool {
+	if node == nil || !node.IsContainer() {
+		return false
+	}
+	for k, v := range c.children {
+		other := node.(Container).Child(k)
+		if other == nil || !v.Equals(other) {
+			return false
+		}
+	}
+	return true
+}
+
 func (c *containerImpl) ensureChildren() {
 	if c.children == nil {
 		c.children = map[string]Node{}

--- a/dom/container_test.go
+++ b/dom/container_test.go
@@ -286,3 +286,15 @@ root:
 		return true
 	})
 }
+
+func TestContainerEquals(t *testing.T) {
+	c := Builder().Container()
+	c.AddValueAt("a.b[1]", LeafNode("123"))
+	c2 := Builder().Container()
+	c2.AddValueAt("a.b[1]", LeafNode("123"))
+
+	assert.False(t, c.Equals(nil))
+	assert.False(t, c.Equals(LeafNode(2)))
+	assert.False(t, c.Equals(Builder().Container()))
+	assert.True(t, c.Equals(c2))
+}

--- a/dom/leaf.go
+++ b/dom/leaf.go
@@ -16,9 +16,15 @@ limitations under the License.
 
 package dom
 
+import "github.com/google/go-cmp/cmp"
+
 type leaf struct {
 	base
 	value interface{}
+}
+
+func (l *leaf) Equals(node Node) bool {
+	return node != nil && node.IsLeaf() && cmp.Equal(l.value, node.(Leaf).Value())
 }
 
 func (l *leaf) SameAs(node Node) bool {

--- a/dom/leaf_test.go
+++ b/dom/leaf_test.go
@@ -34,3 +34,11 @@ func TestLeafValue(t *testing.T) {
 	assert.True(t, l.SameAs(nilLeaf))
 	assert.Equal(t, "abc", l.Value())
 }
+
+func TestLeafEquals(t *testing.T) {
+	l := LeafNode(10)
+	assert.False(t, l.Equals(nil))
+	assert.False(t, l.Equals(LeafNode(11)))
+	assert.False(t, l.Equals(Builder().Container()))
+	assert.True(t, l.Equals(LeafNode(10)))
+}

--- a/dom/list.go
+++ b/dom/list.go
@@ -37,6 +37,22 @@ type listBuilderImpl struct {
 	listImpl
 }
 
+func (l *listBuilderImpl) Equals(node Node) bool {
+	if node == nil || !node.IsList() {
+		return false
+	}
+	otherItems := node.(List).Items()
+	if len(otherItems) != len(l.items) {
+		return false
+	}
+	for i := 0; i < len(l.items); i++ {
+		if !l.items[i].Equals(otherItems[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func (l *listBuilderImpl) SameAs(node Node) bool {
 	return node != nil && node.IsList()
 }

--- a/dom/list_test.go
+++ b/dom/list_test.go
@@ -75,3 +75,18 @@ func TestMustSetOutOfBounds(t *testing.T) {
 	l.MustSet(0, LeafNode(123))
 	assert.Fail(t, "should not be here")
 }
+
+func TestListEquals(t *testing.T) {
+	l := &listBuilderImpl{}
+	l.Append(LeafNode(123))
+	l2 := &listBuilderImpl{}
+	l2.Append(LeafNode(123))
+	l3 := &listBuilderImpl{}
+	l3.Append(LeafNode(456))
+
+	assert.False(t, l.Equals(nil))
+	assert.False(t, l.Equals(nilLeaf))
+	assert.False(t, l.Equals(&listBuilderImpl{}))
+	assert.True(t, l.Equals(l2))
+	assert.False(t, l.Equals(l3))
+}

--- a/dom/types.go
+++ b/dom/types.go
@@ -99,6 +99,9 @@ type List interface {
 	Items() []Node
 }
 
+// NodeList is sequence of zero or more Nodes
+type NodeList []Node
+
 // Container is element that has zero or more child Nodes
 type Container interface {
 	Node

--- a/dom/types.go
+++ b/dom/types.go
@@ -82,6 +82,8 @@ type Node interface {
 	// SameAs returns true if this node is of same type like other node.
 	// The other Node can be nil, in which case return value is false.
 	SameAs(Node) bool
+	// Equals return true is value of this node is equal to value of provided Node.
+	Equals(Node) bool
 }
 
 // Leaf represent Node of scalar value

--- a/patch/helper_test.go
+++ b/patch/helper_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"github.com/rkosegi/yaml-toolkit/dom"
+	"strings"
+)
+
+var (
+	b = dom.Builder()
+)
+
+func makeTestContainer() dom.ContainerBuilder {
+	c, _ := b.FromReader(strings.NewReader(`
+root:
+  list:
+    - item1
+    - sub20: 123
+      sub21: 456
+    - item3
+    - item4
+  sub1:
+    prop: 456
+`), dom.DefaultYamlDecoder)
+	return c
+}

--- a/patch/patch.go
+++ b/patch/patch.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2024 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"errors"
+	"fmt"
+	"github.com/rkosegi/yaml-toolkit/dom"
+)
+
+type Op string
+
+var (
+	ErrNoOo           = errors.New("operations object is nil")
+	ErrNoTarget       = errors.New("target is nil")
+	ErrOoPathMissing  = errors.New("'path' field is missing in operations object")
+	ErrOoValueMissing = errors.New("'value' field is missing in operations object")
+	ErrOoFromMissing  = errors.New("'from' field is missing in operations object")
+)
+
+const (
+	OpAdd     = Op("add")
+	OpRemove  = Op("remove")
+	OpReplace = Op("replace")
+	OpMove    = Op("move")
+	OpCopy    = Op("copy")
+	OpTest    = Op("test")
+)
+
+type opFn func(obj *OpObj, target dom.ContainerBuilder) error
+
+// OpObj is operation object containing all necessary data to perform patch operation
+type OpObj struct {
+	Op    Op
+	From  *Path    // copy,move
+	Path  Path     // test,copy,move,replace,remove,add
+	Value dom.Node // test,replace,add
+}
+
+// Do perform patch operation against designated target.
+// Object is modified in place, or error is returned.
+func Do(obj *OpObj, target dom.ContainerBuilder) error {
+	if obj == nil {
+		return ErrNoOo
+	}
+	if obj.Path == nil {
+		return ErrOoPathMissing
+	}
+	if target == nil {
+		return ErrNoTarget
+	}
+	switch obj.Op {
+	// https://datatracker.ietf.org/doc/html/rfc6902#section-4.1
+	case OpAdd:
+		return doAdd(obj, target)
+
+	// https://datatracker.ietf.org/doc/html/rfc6902#section-4.2
+	case OpRemove:
+		return doRemove(obj, target)
+
+	// https://datatracker.ietf.org/doc/html/rfc6902#section-4.3
+	case OpReplace:
+		return doReplace(obj, target)
+
+	// https://datatracker.ietf.org/doc/html/rfc6902#section-4.4
+	case OpMove:
+		return doMove(obj, target)
+
+	// https://datatracker.ietf.org/doc/html/rfc6902#section-4.5
+	case OpCopy:
+		return doCopy(obj, target)
+
+	// https://datatracker.ietf.org/doc/html/rfc6902#section-4.6
+	case OpTest:
+		return doTest(obj, target)
+	}
+	return fmt.Errorf("invalid operation: %v", obj.Op)
+}
+
+func doAdd(obj *OpObj, target dom.ContainerBuilder) error {
+	if obj.Value == nil {
+		return ErrOoValueMissing
+	}
+	_, parent := obj.Path.Parent().Eval(target)
+	if parent == nil {
+		return fmt.Errorf("parent path does not resolve to existing node: %s", obj.Path.Parent().String())
+	}
+	// If the target location specifies an array index, a new value is
+	//      inserted into the array at the specified index.
+	if idx, isNum := obj.Path.LastSegment().IsNumeric(); isNum && parent.IsList() {
+		insertListItem(parent.(dom.ListBuilder), idx, obj.Value)
+		return nil
+	} else {
+		// If the target location specifies an object member that does not
+		//      already exist, a new member is added to the object.
+		// If the target location specifies an object member that does exist,
+		//      that member's value is replaced.
+		parent.(dom.ContainerBuilder).AddValue(string(obj.Path.LastSegment()), obj.Value)
+	}
+	return nil
+}
+
+func doRemove(obj *OpObj, target dom.ContainerBuilder) error {
+	_, n := obj.Path.Eval(target)
+	// The target location MUST exist for the operation to be successful.
+	if n == nil {
+		return fmt.Errorf("node at path %s does not exists", obj.Path.String())
+	}
+	_, parent := obj.Path.Parent().Eval(target)
+	if idx, isNum := obj.Path.LastSegment().IsNumeric(); isNum && parent.IsList() {
+		// If removing an element from an array, any elements above the
+		//		specified index are shifted one position to the left.
+		removeListItem(parent.(dom.ListBuilder), idx)
+	} else {
+		parent.(dom.ContainerBuilder).Remove(string(obj.Path.LastSegment()))
+	}
+	return nil
+}
+
+func doReplace(obj *OpObj, target dom.ContainerBuilder) error {
+	if obj.Value == nil {
+		return ErrOoValueMissing
+	}
+	nl, n := obj.Path.Eval(target)
+	// The target location MUST exist for the operation to be successful.
+	if n == nil {
+		return fmt.Errorf("path does not resolve to existing node: %s", obj.Path.String())
+	}
+	parent := nl[len(nl)-2]
+	if idx, isNum := obj.Path.LastSegment().IsNumeric(); isNum && parent.IsList() {
+		parent.(dom.ListBuilder).Set(uint(idx), obj.Value)
+	} else {
+		parent.(dom.ContainerBuilder).AddValue(string(obj.Path.LastSegment()), obj.Value)
+	}
+	return nil
+}
+
+func doMove(obj *OpObj, target dom.ContainerBuilder) error {
+	// This operation is functionally identical to a "remove" operation on
+	//   the "from" location, followed immediately by an "add" operation at
+	//   the target location with the value that was just removed.
+	return moveOrCopy(obj, target, true)
+}
+
+func doCopy(obj *OpObj, target dom.ContainerBuilder) error {
+	// This operation is functionally identical to an "add" operation at the
+	//   target location using the value specified in the "from" member.
+	return moveOrCopy(obj, target, false)
+}
+
+func moveOrCopy(obj *OpObj, target dom.ContainerBuilder, move bool) error {
+	if obj.From == nil {
+		return ErrOoFromMissing
+	}
+	// The "from" location MUST exist for the operation to be successful.
+	n, err := get(*obj.From, target)
+	if err != nil {
+		return err
+	}
+	if move {
+		_ = doRemove(&OpObj{
+			Path: *obj.From,
+		}, target)
+	}
+
+	return doAdd(&OpObj{Value: n, Path: obj.Path}, target)
+}
+
+func doTest(obj *OpObj, target dom.ContainerBuilder) error {
+	if obj.Value == nil {
+		return ErrOoValueMissing
+	}
+	if n, err := get(obj.Path, target); err != nil {
+		return err
+	} else if !obj.Value.Equals(n) {
+		return fmt.Errorf("node at path %s with value %v does not match expected value of %v", obj.Path, n, obj.Value)
+	}
+	return nil
+}
+
+func get(path Path, target dom.ContainerBuilder) (dom.Node, error) {
+	_, n := path.Eval(target)
+	if n == nil {
+		return nil, fmt.Errorf("path does not resolve to existing node: %s", path.String())
+	}
+	return n, nil
+}

--- a/patch/patch_test.go
+++ b/patch/patch_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2024 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"github.com/rkosegi/yaml-toolkit/dom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMissing(t *testing.T) {
+	var err error
+	err = Do(nil, b.Container())
+	assert.Error(t, err)
+	err = Do(&OpObj{}, b.Container())
+	assert.Error(t, err)
+	err = Do(&OpObj{
+		Path: emptyPath,
+	}, nil)
+	assert.Error(t, err)
+	err = Do(&OpObj{
+		Path: emptyPath,
+	}, makeTestContainer())
+	assert.Error(t, err)
+}
+
+func TestPatchOpAdd(t *testing.T) {
+	var (
+		c   dom.ContainerBuilder
+		err error
+	)
+	c = makeTestContainer()
+	// value missing
+	err = Do(&OpObj{
+		Op:   OpAdd,
+		Path: MustParsePath("/root/list/2"),
+	}, c)
+	assert.Error(t, err)
+	// parent not resolvable
+	err = Do(&OpObj{
+		Op:    OpAdd,
+		Path:  MustParsePath("/root/not-existent/2"),
+		Value: dom.LeafNode(1),
+	}, c)
+	assert.Error(t, err)
+
+	err = Do(&OpObj{
+		Op:    OpAdd,
+		Path:  MustParsePath("/root/leaf20"),
+		Value: dom.LeafNode(1),
+	}, c)
+	assert.NoError(t, err)
+
+	c = makeTestContainer()
+	assert.Equal(t, 4, len(c.Lookup("root.list").(dom.List).Items()))
+	err = Do(&OpObj{
+		Op:    OpAdd,
+		Path:  MustParsePath("/root/list/2"),
+		Value: dom.LeafNode(1),
+	}, c)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, len(c.Lookup("root.list").(dom.List).Items()))
+	assert.Equal(t, 1, c.Lookup("root.list[2]").(dom.Leaf).Value())
+}
+
+func TestPatchOpRemove(t *testing.T) {
+	var (
+		c   dom.ContainerBuilder
+		err error
+	)
+	c = makeTestContainer()
+	err = Do(&OpObj{
+		Op:   OpRemove,
+		Path: MustParsePath("/not/exists/10"),
+	}, c)
+	assert.Error(t, err)
+	assert.Equal(t, 4, len(c.Lookup("root.list").(dom.List).Items()))
+	err = Do(&OpObj{
+		Op:   OpRemove,
+		Path: MustParsePath("/root/list/0"),
+	}, c)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(c.Lookup("root.list").(dom.List).Items()))
+
+	c = makeTestContainer()
+	err = Do(&OpObj{
+		Op:   OpRemove,
+		Path: MustParsePath("/root/list/2"),
+	}, c)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(c.Lookup("root.list").(dom.List).Items()))
+	assert.Equal(t, "item4", c.Lookup("root.list[2]").(dom.Leaf).Value())
+
+	err = Do(&OpObj{
+		Op:   OpRemove,
+		Path: MustParsePath("/root/list"),
+	}, c)
+	assert.NoError(t, err)
+	assert.Nil(t, c.Lookup("root.list"))
+}
+
+func TestPatchOpReplace(t *testing.T) {
+	var (
+		c   dom.ContainerBuilder
+		err error
+	)
+	c = makeTestContainer()
+	// value missing
+	err = Do(&OpObj{
+		Op:   OpReplace,
+		Path: emptyPath,
+	}, c)
+	assert.Error(t, err)
+	err = Do(&OpObj{
+		Op:    OpReplace,
+		Path:  MustParsePath("/root/sub1"),
+		Value: dom.LeafNode("abc"),
+	}, c)
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", c.Lookup("root.sub1").(dom.Leaf).Value())
+	err = Do(&OpObj{
+		Op:    OpReplace,
+		Path:  MustParsePath("/root/non-existent/path"),
+		Value: dom.LeafNode("abc"),
+	}, c)
+	assert.Error(t, err)
+	assert.Equal(t, 4, len(c.Lookup("root.list").(dom.List).Items()))
+	err = Do(&OpObj{
+		Op:    OpReplace,
+		Path:  MustParsePath("/root/list/1"),
+		Value: dom.LeafNode("abc"),
+	}, c)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(c.Lookup("root.list").(dom.List).Items()))
+	assert.Equal(t, "abc", c.Lookup("root.list[1]").(dom.Leaf).Value())
+}
+
+func TestPatchOpMove(t *testing.T) {
+	var err error
+	// missing "from"
+	err = Do(&OpObj{
+		Op:    OpMove,
+		Path:  MustParsePath("/root/sub1/prop2"),
+		Value: dom.LeafNode(1),
+	}, makeTestContainer())
+	assert.Error(t, err)
+	f := MustParsePath("/root/sub1/prop")
+	c := makeTestContainer()
+	err = Do(&OpObj{
+		Op:   OpMove,
+		Path: MustParsePath("/root/sub1/prop2"),
+		From: &f,
+	}, c)
+	assert.NoError(t, err)
+	assert.Nil(t, c.Lookup("root.sub1.prop"))
+	assert.Equal(t, 456, c.Lookup("root.sub1.prop2").(dom.Leaf).Value())
+}
+
+func TestPatchOpCopy(t *testing.T) {
+	var (
+		err error
+		c   dom.ContainerBuilder
+		f   Path
+	)
+	// missing "from"
+	err = Do(&OpObj{
+		Op:    OpCopy,
+		Path:  MustParsePath("/root/sub1/prop2"),
+		Value: dom.LeafNode(1),
+	}, makeTestContainer())
+	assert.Error(t, err)
+	f = MustParsePath("/root/sub1/prop")
+	c = makeTestContainer()
+	err = Do(&OpObj{
+		Op:   OpCopy,
+		Path: MustParsePath("/root/sub1/prop2"),
+		From: &f,
+	}, c)
+	assert.NoError(t, err)
+	assert.Equal(t, 456, c.Lookup("root.sub1.prop").(dom.Leaf).Value())
+	assert.Equal(t, 456, c.Lookup("root.sub1.prop2").(dom.Leaf).Value())
+	f = MustParsePath("/root/sub10/prop10")
+	c = makeTestContainer()
+	err = Do(&OpObj{
+		Op:   OpCopy,
+		Path: MustParsePath("/root/sub1/prop2"),
+		From: &f,
+	}, c)
+	assert.Error(t, err)
+}
+
+func TestPatchOpTest(t *testing.T) {
+	var err error
+	// missing value
+	err = Do(&OpObj{
+		Op:    OpTest,
+		Path:  emptyPath,
+		Value: nil,
+	}, makeTestContainer())
+	assert.Error(t, err)
+	// positive case
+	err = Do(&OpObj{
+		Op:    OpTest,
+		Path:  MustParsePath("/root/list/0"),
+		Value: dom.LeafNode("item1"),
+	}, makeTestContainer())
+	assert.NoError(t, err)
+	// value mismatch
+	err = Do(&OpObj{
+		Op:    OpTest,
+		Path:  MustParsePath("/root/list/0"),
+		Value: dom.LeafNode("item2"),
+	}, makeTestContainer())
+	assert.Error(t, err)
+	// unresolvable path
+	err = Do(&OpObj{
+		Op:    OpTest,
+		Path:  MustParsePath("/root/list1/0"),
+		Value: dom.LeafNode("item2"),
+	}, makeTestContainer())
+	assert.Error(t, err)
+}

--- a/patch/path.go
+++ b/patch/path.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"fmt"
+	"github.com/rkosegi/yaml-toolkit/dom"
+	"strconv"
+	"strings"
+)
+
+type PathSegment string
+
+// TODO add support for "-" - the "last" item designation
+func (ps PathSegment) IsNumeric() (int, bool) {
+	i, err := strconv.Atoi(string(ps))
+	return i, err == nil
+}
+
+type Path []PathSegment
+
+func (p Path) Parent() Path {
+	if len(p) <= 1 {
+		return nil
+	}
+	return p[0 : len(p)-1]
+}
+
+func (p Path) LastSegment() PathSegment {
+	if len(p) == 0 {
+		return ""
+	}
+	return p[len(p)-1]
+}
+
+// String returns lexical representation of this path according to RFC
+func (p Path) String() string {
+	if len(p) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, ps := range p {
+		sb.WriteRune('/')
+		rps := []rune(ps)
+		for i := 0; i < len(rps); i++ {
+			if rps[i] == '~' {
+				sb.WriteString("~0")
+			} else if rps[i] == '/' {
+				sb.WriteString("~1")
+			} else {
+				sb.WriteRune(rps[i])
+			}
+		}
+	}
+	return sb.String()
+}
+
+var emptyPath = Path{}
+
+func MustParsePath(pathSpec string) Path {
+	p, err := ParsePath(pathSpec)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func ParsePath(pathSpec string) (Path, error) {
+	if pathSpec == "" {
+		// special case that match anything
+		return emptyPath, nil
+	}
+	if !strings.HasPrefix(pathSpec, "/") {
+		return nil, fmt.Errorf("path must start with '/':%s", pathSpec)
+	}
+	// strip leading slash
+	pathSpec = pathSpec[1:]
+	rps := []rune(pathSpec)
+	ps := make([]PathSegment, 0)
+	cs := strings.Builder{}
+	for i := 0; i < len(rps); i++ {
+		c := rps[i]
+		switch c {
+		case '~':
+			// check if there is room to look ahead
+			if i < len(rps)-1 {
+				// https://datatracker.ietf.org/doc/html/rfc6901#section-4
+				// first transforming any occurrence of the sequence '~1' to '/'
+				if rps[i+1] == '1' {
+					cs.WriteRune('/')
+					i++
+				} else
+				// then transforming any occurrence of the sequence '~0' to '~'
+				if rps[i+1] == '0' {
+					cs.WriteRune('~')
+					i++
+				} else {
+					// not a special case, just regular character
+					cs.WriteRune(c)
+				}
+			} else {
+				// tilda is very last character
+				cs.WriteRune(c)
+			}
+		case '/':
+			ps = append(ps, PathSegment(cs.String()))
+			cs.Reset()
+		default:
+			cs.WriteRune(c)
+		}
+	}
+	ps = append(ps, PathSegment(cs.String()))
+	cs.Reset()
+	return ps, nil
+}
+
+// Eval evaluates path within provided target dom.Container. Call to this function returns pair,
+// where one part is series of Nodes encountered while walking from root of target dom.Container down the path, second part is final Node.
+// If path does not fully resolve, second part will be nil, while first part will contain all Nodes up to point where resolution stopped.
+func (p Path) Eval(target dom.Container) (dom.NodeList, dom.Node) {
+	var (
+		curr dom.Node
+		res  dom.NodeList
+	)
+	// special case, empty path resolves to "whole document" so return target as-is.
+	if len(p) == 0 {
+		return []dom.Node{target}, target
+	}
+	curr = target
+	res = make([]dom.Node, 0)
+
+	for _, ps := range p {
+		// first try list item
+		if curr.IsList() {
+			if idx, isIndex := ps.IsNumeric(); isIndex {
+				l := curr.(dom.List)
+				if len(l.Items()) > idx {
+					curr = l.Items()[idx]
+					res = append(res, curr)
+				} else {
+					// list index out of bounds
+					return res, nil
+				}
+			}
+		} else
+		// regular child within container
+		{
+			if !curr.IsContainer() {
+				return res, nil
+			} else {
+				curr = curr.(dom.Container).Child(string(ps))
+				if curr == nil {
+					return res, nil
+				}
+				res = append(res, curr)
+			}
+		}
+	}
+	return res, curr
+}

--- a/patch/path_test.go
+++ b/patch/path_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2024 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"github.com/rkosegi/yaml-toolkit/dom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParsePath(t *testing.T) {
+	var (
+		p   Path
+		err error
+	)
+	_, err = ParsePath("a")
+	assert.Error(t, err)
+	p, err = ParsePath("/a/b/c")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(p))
+	assert.Equal(t, "a", string(p[0]))
+	assert.Equal(t, "b", string(p[1]))
+	assert.Equal(t, "c", string(p[2]))
+	p, err = ParsePath("")
+	assert.NoError(t, err)
+	assert.Equal(t, emptyPath, p)
+	p, err = ParsePath("/a/b/c~1")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(p))
+	p, err = ParsePath("/a/xyz~0123/~")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(p))
+	assert.Equal(t, "a", string(p[0]))
+	assert.Equal(t, "xyz~123", string(p[1]))
+	assert.Equal(t, "~", string(p[2]))
+	p, err = ParsePath("/a/~3/mnop")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(p))
+	assert.Equal(t, "a", string(p[0]))
+	assert.Equal(t, "~3", string(p[1]))
+	assert.Equal(t, "mnop", string(p[2]))
+}
+
+func TestMustParsePathInvalid(t *testing.T) {
+	defer func() {
+		recover()
+	}()
+	MustParsePath("invalid")
+	assert.Fail(t, "should not be here")
+}
+func TestMustParsePath(t *testing.T) {
+	p := MustParsePath("")
+	assert.Equal(t, emptyPath, p)
+}
+
+func TestPathString(t *testing.T) {
+	assert.Equal(t, "/a/x~1y/c", Path{"a", "x/y", "c"}.String())
+	assert.Equal(t, "/a/x~0y/c", Path{"a", "x~y", "c"}.String())
+	assert.Equal(t, "", Path{}.String())
+}
+
+func TestEvaluate(t *testing.T) {
+	var (
+		p   Path
+		n   dom.Node
+		nl  dom.NodeList
+		err error
+	)
+	c := makeTestContainer()
+	assert.NoError(t, err)
+	p, _ = ParsePath("/root/list/0/c")
+	_, n = p.Eval(c)
+	assert.Nil(t, n)
+	p, _ = ParsePath("/root/list/0")
+	_, n = p.Eval(c)
+	assert.NotNil(t, n)
+	assert.Equal(t, "item1", n.(dom.Leaf).Value())
+	p, _ = ParsePath("/root/sub1")
+	_, n = p.Eval(c)
+	assert.NotNil(t, n)
+	assert.True(t, n.IsContainer())
+	p, _ = ParsePath("/root/sub1/prop")
+	_, n = p.Eval(c)
+	assert.NotNil(t, n)
+	assert.Equal(t, 456, n.(dom.Leaf).Value())
+	p, _ = ParsePath("/root/list/10")
+	_, n = p.Eval(c)
+	assert.Nil(t, n)
+	p, _ = ParsePath("/root/sub1/prop2")
+	_, n = p.Eval(c)
+	assert.Nil(t, n)
+	nl, _ = p.Eval(c)
+	assert.NotNil(t, nl)
+	assert.Equal(t, 2, len(nl))
+	_, n = p.Parent().Eval(c)
+	assert.NotNil(t, n)
+	nl, n = emptyPath.Eval(c)
+	assert.Equal(t, 1, len(nl))
+	assert.Equal(t, c, nl[0])
+	assert.Equal(t, c, n)
+}
+
+func TestPathParent(t *testing.T) {
+	var (
+		p Path
+	)
+	p, _ = ParsePath("/x/y/z")
+	p = p.Parent()
+	assert.Equal(t, 2, len(p))
+	assert.Equal(t, "y", string(p[1]))
+	assert.Equal(t, "x", string(p[0]))
+	p = p.Parent()
+	assert.Equal(t, 1, len(p))
+	assert.Equal(t, "x", string(p[0]))
+	p = p.Parent()
+	assert.Equal(t, 0, len(p))
+}
+
+func TestPathLastSegment(t *testing.T) {
+	var (
+		p Path
+	)
+	p, _ = ParsePath("/x/y/z")
+	assert.Equal(t, "z", string(p.LastSegment()))
+
+	p, _ = ParsePath("")
+	assert.Equal(t, "", string(p.LastSegment()))
+}

--- a/patch/utils.go
+++ b/patch/utils.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import "github.com/rkosegi/yaml-toolkit/dom"
+
+// removeListItem deletes item from given list. remaining Nodes are shifted to left by one
+func removeListItem(list dom.ListBuilder, removeAt int) {
+	items := list.Items()
+	list.Clear()
+	for i := 0; i < removeAt; i++ {
+		list.Append(items[i])
+	}
+	for i := removeAt + 1; i < len(items); i++ {
+		list.Append(items[i])
+	}
+}
+
+// insertListItem inserts Node at given index.
+func insertListItem(list dom.ListBuilder, insertAt int, toInsert dom.Node) {
+	items := list.Items()
+	list.Clear()
+	for i := 0; i < insertAt; i++ {
+		list.Append(items[i])
+	}
+	list.Append(toInsert)
+	for i := insertAt; i < len(items); i++ {
+		list.Append(items[i])
+	}
+}

--- a/patch/utils_test.go
+++ b/patch/utils_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"github.com/rkosegi/yaml-toolkit/dom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRemoveListItem(t *testing.T) {
+	l := dom.ListNode(dom.LeafNode(1), dom.LeafNode(2), dom.LeafNode(3))
+	assert.Equal(t, 3, len(l.Items()))
+	removeListItem(l, 1)
+	assert.Equal(t, 2, len(l.Items()))
+	assert.Equal(t, 1, l.Items()[0].(dom.Leaf).Value())
+	assert.Equal(t, 3, l.Items()[1].(dom.Leaf).Value())
+}
+
+func TestInsertListItem(t *testing.T) {
+	l := dom.ListNode(dom.LeafNode("a"), dom.LeafNode("b"), dom.LeafNode("c"))
+	assert.Equal(t, 3, len(l.Items()))
+	insertListItem(l, 3, dom.LeafNode("d"))
+	assert.Equal(t, 4, len(l.Items()))
+	assert.Equal(t, "d", l.Items()[3].(dom.Leaf).Value())
+}


### PR DESCRIPTION
Add support for 
 - [RFC6901 - JavaScript Object Notation (JSON) Pointer](https://datatracker.ietf.org/doc/html/rfc6901)
 - [RFC6902 - JavaScript Object Notation (JSON) Patch](https://datatracker.ietf.org/doc/html/rfc6902)