### PR TITLE
DOM: Fix sematics of ContainerBuilder.FromMap()

### DIFF
--- a/dom/container.go
+++ b/dom/container.go
@@ -333,11 +333,9 @@ func (f *containerFactory) FromAny(v interface{}) ContainerBuilder {
 }
 
 func (f *containerFactory) FromMap(in map[string]interface{}) ContainerBuilder {
-	b := f.Container()
-	for k, v := range in {
-		b.AddValueAt(k, LeafNode(v))
-	}
-	return b
+	doc := containerBuilderImpl{}
+	appendMap(&in, &doc)
+	return &doc
 }
 
 func (f *containerFactory) Container() ContainerBuilder {
@@ -349,9 +347,7 @@ func (f *containerFactory) FromReader(r io.Reader, fn DecoderFunc) (ContainerBui
 	if err := fn(r, &root); err != nil {
 		return nil, err
 	} else {
-		doc := containerBuilderImpl{}
-		appendMap(&root, &doc)
-		return &doc, err
+		return f.FromMap(root), nil
 	}
 }
 

--- a/dom/container_test.go
+++ b/dom/container_test.go
@@ -145,19 +145,19 @@ func TestFromMap(t *testing.T) {
 		"test1.test2":  "abc",
 		"test1.test22": 123,
 	})
-	assert.Equal(t, "abc", c.Lookup("test1.test2").(Leaf).Value())
+	assert.Equal(t, "abc", c.Child("test1.test2").(Leaf).Value())
 }
 
 func TestRemoveAt(t *testing.T) {
 	c := b.FromMap(map[string]interface{}{
-		"test1.test2":       "abc",
-		"test1.test22":      123,
-		"testA.testB.testC": "Hi",
+		"test2":  "abc",
+		"test22": 123,
+		"testC":  "Hi",
 	})
-	c.RemoveAt("testA.non-existing.another")
-	assert.NotNil(t, c.Lookup("test1.test22"))
-	c.RemoveAt("test1.test22")
-	assert.Nil(t, c.Lookup("test1.test22"))
+	c.RemoveAt("non-existing.another")
+	assert.NotNil(t, c.Child("test22"))
+	c.RemoveAt("test22")
+	assert.Nil(t, c.Child("test22"))
 }
 
 func TestAddValueAt(t *testing.T) {


### PR DESCRIPTION
Up until this commit, FromMap() treated map keys as property paths,
which means ANY value is coerced into LeafNode.
More correct behavior is to not treat them as such, but pass them as-is
into existing code (appendMap). This will simplify code path and make
it more logical overall.

Previous behavior can be easily achieved to foreign callers using public API:

```go
       c := dom.Builder().Container()
       for k, v := range in {
               c.AddValueAt(k, dom.LeafNode(v))
       }
       return c
```

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
