### PR TITLE
DOM: Implement Walk on whole overlay document

### DIFF
--- a/dom/overlay_test.go
+++ b/dom/overlay_test.go
@@ -154,3 +154,28 @@ func TestOverlayAdd(t *testing.T) {
 	d.Add("layer1", c)
 	assert.Equal(t, 123, d.Layers()["layer1"].Children()["sub1.sub2"].(Leaf).Value())
 }
+
+func TestOverlayWalk(t *testing.T) {
+	d := NewOverlayDocument()
+	d.Put("layer1", "root.sub10.sub21", LeafNode("leaf1"))
+	d.Put("layer2", "root.sub11.list22", ListNode(
+		LeafNode(1),
+		LeafNode(2),
+		LeafNode(3),
+	))
+	var cnt int
+	d.Walk(func(layer, path string, parent Node, node Node) bool {
+		cnt++
+		if node.IsLeaf() && node.(Leaf).Value() == 2 {
+			return false
+		}
+		return true
+	})
+	assert.Equal(t, 3, cnt)
+	cnt = 0
+	d.Walk(func(layer, path string, parent Node, node Node) bool {
+		cnt++
+		return true
+	})
+	assert.Equal(t, 4, cnt)
+}

--- a/dom/types.go
+++ b/dom/types.go
@@ -145,6 +145,10 @@ type ContainerBuilder interface {
 
 type WalkFn func(path string, parent ContainerBuilder, node Node) bool
 
+// OverlayVisitorFn visits every node in OverlayDocument.
+// Returning false from this function will cause termination of process.
+type OverlayVisitorFn func(layer, path string, parent Node, node Node) bool
+
 var (
 	// CompactFn is WalkFn that you can use to compact document tree by removing empty containers.
 	CompactFn = func(path string, parent ContainerBuilder, node Node) bool {
@@ -218,4 +222,6 @@ type OverlayDocument interface {
 	// Layers returns a copy of mapping between layer name and its associated Container.
 	// Containers are cloned using Node.Clone()
 	Layers() map[string]Container
+	// Walk walks every layer in this document and visits every node.
+	Walk(fn OverlayVisitorFn)
 }


### PR DESCRIPTION
This allows to traverse every layer and every node within overlay document

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
