### PR TITLE
DOM: Expose layer names as a list

### DIFF
--- a/dom/overlay.go
+++ b/dom/overlay.go
@@ -77,6 +77,12 @@ func (m *overlayDocument) Layers() map[string]Container {
 	return c
 }
 
+func (m *overlayDocument) LayerNames() []string {
+	names := make([]string, len(m.names))
+	copy(names, m.names)
+	return names
+}
+
 func (m *overlayDocument) Add(overlay string, value Container) {
 	cb := m.ensureOverlay(overlay)
 	for k, v := range value.Children() {

--- a/dom/overlay_test.go
+++ b/dom/overlay_test.go
@@ -18,6 +18,7 @@ package dom
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 	"os"
@@ -144,6 +145,19 @@ func TestOverlayLayers(t *testing.T) {
 	m := d.Layers()
 	assert.Equal(t, 2, len(m))
 	assert.Equal(t, 5, m["layer2"].Children()["root"].(Container).Children()["other"].(Leaf).Value())
+}
+
+func TestOverlayLayerNames(t *testing.T) {
+	layers := 10
+	d := NewOverlayDocument()
+	for i := 0; i < layers; i++ {
+		d.Put(fmt.Sprintf("layer-%d", i), "root", LeafNode(i))
+	}
+	m := d.LayerNames()
+	assert.Equal(t, layers, len(m))
+	for i := 0; i < layers; i++ {
+		assert.Equal(t, fmt.Sprintf("layer-%d", i), m[i])
+	}
 }
 
 func TestOverlayAdd(t *testing.T) {

--- a/dom/types.go
+++ b/dom/types.go
@@ -222,6 +222,8 @@ type OverlayDocument interface {
 	// Layers returns a copy of mapping between layer name and its associated Container.
 	// Containers are cloned using Node.Clone()
 	Layers() map[string]Container
+	// LayerNames returns copy of list of all layer names, in insertion order
+	LayerNames() []string
 	// Walk walks every layer in this document and visits every node.
 	Walk(fn OverlayVisitorFn)
 }


### PR DESCRIPTION
This is required when insertion order needs to be evaluated by consumers

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
