### PR TITLE
DOM: Preserve layer insertion order when invoking Walk

### DIFF
--- a/dom/overlay.go
+++ b/dom/overlay.go
@@ -267,8 +267,9 @@ func walkContainer(layer, path string, con ContainerBuilder, fn OverlayVisitorFn
 }
 
 func (m *overlayDocument) Walk(fn OverlayVisitorFn) {
-	for l, c := range m.overlays {
-		if !walkContainer(l, "", c, fn) {
+	for _, n := range m.names {
+		c := m.overlays[n]
+		if !walkContainer(n, "", c, fn) {
 			return
 		}
 	}

--- a/dom/overlay_test.go
+++ b/dom/overlay_test.go
@@ -179,8 +179,10 @@ func TestOverlayWalk(t *testing.T) {
 	))
 	var cnt int
 	d.Walk(func(layer, path string, parent Node, node Node) bool {
+		t.Logf("layer=%s, path=%s, parent=%v, node=%v", layer, path, parent, node)
 		cnt++
 		if node.IsLeaf() && node.(Leaf).Value() == 2 {
+			t.Logf("Hit false condition, terminating walk")
 			return false
 		}
 		return true


### PR DESCRIPTION
Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
