### PR TITLE
DOM: Re-introduce way to initialise Container from properties

### DIFF
--- a/analytics/placeholder_resolver_test.go
+++ b/analytics/placeholder_resolver_test.go
@@ -32,7 +32,7 @@ func TestIsPossiblePlaceholder(t *testing.T) {
 
 func TestResolvePlaceholders(t *testing.T) {
 	ds := NewDocumentSet()
-	ds.AddUnnamedDocument(b.FromMap(map[string]interface{}{
+	assert.NoError(t, ds.AddUnnamedDocument(b.FromProperties(map[string]interface{}{
 		"key1.key2.key31": "${key1.key2.key32}",
 		"key1.key2.key32": 3,
 		"key1.key2.key33": "${key1.key2.key34}",
@@ -40,7 +40,7 @@ func TestResolvePlaceholders(t *testing.T) {
 		"key1.key2.key41": "${key1.key2.key42}",
 		"key1.key2.key42": "${unresolved}",
 		"key1.key2.key43": "${unresolved}",
-	}))
+	})))
 	res := NewPlaceholderResolverBuilder().
 		OnResolutionFailure(func(key, value string, coordinates dom.Coordinates) {
 			t.Logf("resolution failed,key=%s, value=%s, coordinates=%s", key, value, coordinates.String())
@@ -55,9 +55,9 @@ func TestResolvePlaceholders(t *testing.T) {
 		Build()
 	rpt := res.Resolve(ds.AsOne())
 
-	assert.Equal(t, 6, len(rpt.FailedKeys))
+	assert.Equal(t, 3, len(rpt.FailedKeys))
 	res = NewPlaceholderResolverBuilder().
 		Build()
 	rpt = res.Resolve(ds.AsOne())
-	assert.Equal(t, 6, len(rpt.FailedKeys))
+	assert.Equal(t, 3, len(rpt.FailedKeys))
 }

--- a/dom/container.go
+++ b/dom/container.go
@@ -338,6 +338,14 @@ func (f *containerFactory) FromMap(in map[string]interface{}) ContainerBuilder {
 	return &doc
 }
 
+func (f *containerFactory) FromProperties(in map[string]interface{}) ContainerBuilder {
+	b := f.Container()
+	for k, v := range in {
+		b.AddValueAt(k, LeafNode(v))
+	}
+	return b
+}
+
 func (f *containerFactory) Container() ContainerBuilder {
 	return &containerBuilderImpl{}
 }

--- a/dom/container_test.go
+++ b/dom/container_test.go
@@ -148,6 +148,16 @@ func TestFromMap(t *testing.T) {
 	assert.Equal(t, "abc", c.Child("test1.test2").(Leaf).Value())
 }
 
+func TestFromProperties(t *testing.T) {
+	c := b.FromProperties(map[string]interface{}{
+		"test1.test2":  "abc",
+		"test1.test22": 123,
+	})
+	assert.Equal(t, 1, len(c.Children()))
+	assert.Equal(t, 2, len(c.Children()["test1"].(Container).Children()))
+	assert.Equal(t, "abc", c.Lookup("test1.test2").(Leaf).Value())
+}
+
 func TestRemoveAt(t *testing.T) {
 	c := b.FromMap(map[string]interface{}{
 		"test2":  "abc",

--- a/dom/types.go
+++ b/dom/types.go
@@ -168,6 +168,8 @@ type ContainerFactory interface {
 	FromReader(r io.Reader, fn DecoderFunc) (ContainerBuilder, error)
 	// FromMap creates ContainerBuilder pre-populated with data from provided map
 	FromMap(in map[string]interface{}) ContainerBuilder
+	// FromProperties is similar to FromMap except that keys are parsed into path before inserting into ContainerBuilder
+	FromProperties(in map[string]interface{}) ContainerBuilder
 	// FromAny creates ContainerBuilder from any object. Any error encountered in process will result in panic.
 	// This method uses YAML codec internally to perform translation between raw interface and map
 	FromAny(v interface{}) ContainerBuilder


### PR DESCRIPTION
Fix introduced in #10 changed FromMap() semantics,
which might still be desirable in some cases. Create factory method
FromProperties() that will use old way of initialising

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
