### PR TITLE
Pipeline: Add support for different strategy when using Set operation.

### DIFF
--- a/pipeline/set_op_test.go
+++ b/pipeline/set_op_test.go
@@ -53,3 +53,79 @@ func TestExecuteSetOp(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, ErrNoDataToSet, err)
 }
+
+func TestSetOpInvalidSetStrategy(t *testing.T) {
+	assert.Error(t, New().Execute(&SetOp{
+		Data:     map[string]interface{}{},
+		Strategy: setStrategyPointer("unknown"),
+	}))
+}
+
+func TestSetOpMergeRoot(t *testing.T) {
+	var (
+		gd dom.ContainerBuilder
+		ss SetOp
+	)
+
+	ss = SetOp{
+		Data: map[string]interface{}{
+			"sub1": 123,
+		},
+		Strategy: setStrategyPointer(SetStrategyMerge),
+	}
+	gd = b.Container()
+	gd.AddValue("sub2", dom.LeafNode(1))
+	assert.NoError(t, New(WithData(gd)).Execute(&ss))
+	assert.Equal(t, 123, gd.Lookup("sub1").(dom.Leaf).Value())
+	assert.Equal(t, 2, len(gd.Children()))
+
+	gd = b.Container()
+	gd.AddValueAt("sub2.sub3a", dom.LeafNode(2))
+	ss = SetOp{
+		Data: map[string]interface{}{
+			"sub2": map[string]interface{}{
+				"sub3b": 123,
+			},
+		},
+		Strategy: setStrategyPointer(SetStrategyMerge),
+	}
+	assert.NoError(t, New(WithData(gd)).Execute(&ss))
+	assert.Equal(t, 2, len(gd.Lookup("sub2").(dom.Container).Children()))
+	assert.Equal(t, 2, gd.Lookup("sub2.sub3a").(dom.Leaf).Value())
+	assert.Equal(t, 123, gd.Lookup("sub2.sub3b").(dom.Leaf).Value())
+}
+
+func TestSetOpMergeSubPath(t *testing.T) {
+	var (
+		gd dom.ContainerBuilder
+		ss SetOp
+	)
+
+	ss = SetOp{
+		Data: map[string]interface{}{
+			"sub20": 123,
+		},
+		Strategy: setStrategyPointer(SetStrategyMerge),
+		Path:     "sub10",
+	}
+	gd = b.Container()
+
+	assert.NoError(t, New(WithData(gd)).Execute(&ss))
+	assert.Equal(t, 123, gd.Lookup("sub10.sub20").(dom.Leaf).Value())
+
+	gd = b.Container()
+	gd.AddValueAt("sub10.sub20.sub30", dom.LeafNode(2))
+	ss = SetOp{
+		Data: map[string]interface{}{
+			"sub20": map[string]interface{}{
+				"sub3b": 123,
+			},
+		},
+		Path:     "sub10",
+		Strategy: setStrategyPointer(SetStrategyMerge),
+	}
+	assert.NoError(t, New(WithData(gd)).Execute(&ss))
+	assert.Equal(t, 2, len(gd.Lookup("sub10.sub20").(dom.Container).Children()))
+	assert.Equal(t, 2, gd.Lookup("sub10.sub20.sub30").(dom.Leaf).Value())
+	assert.Equal(t, 123, gd.Lookup("sub10.sub20.sub3b").(dom.Leaf).Value())
+}

--- a/pipeline/types.go
+++ b/pipeline/types.go
@@ -217,6 +217,13 @@ type PatchOp struct {
 	Value map[string]interface{} `yaml:"value,omitempty"`
 }
 
+type SetStrategy string
+
+const (
+	SetStrategyReplace = SetStrategy("replace")
+	SetStrategyMerge   = SetStrategy("merge")
+)
+
 // SetOp sets data in global data document at given path.
 type SetOp struct {
 	// Arbitrary data to put into data tree
@@ -225,6 +232,9 @@ type SetOp struct {
 	// Path at which to put data.
 	// If omitted, then data are merged into root of document
 	Path string `yaml:"path,omitempty"`
+
+	// Strategy defines how that are handled when conflict during set/add of data occur.
+	Strategy *SetStrategy `yaml:"strategy,omitempty"`
 }
 
 // TemplateOp can be used to render value from data at runtime.

--- a/pipeline/utils.go
+++ b/pipeline/utils.go
@@ -46,6 +46,10 @@ func safeStrDeref(in *string) string {
 	return *in
 }
 
+func setStrategyPointer(s SetStrategy) *SetStrategy {
+	return &s
+}
+
 func safeRegexpDeref(re *regexp.Regexp) string {
 	if re == nil {
 		return ""


### PR DESCRIPTION
Previously, data were simply replaced while setting data.
This change allow to override this behavior to perform merge instead.

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
