### PR TITLE
DOM: Reverse order of nodes in coalesce

### DIFF
--- a/dom/merge.go
+++ b/dom/merge.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package dom
 
-import "math"
+import (
+	"math"
+	"slices"
+)
 
 func defaultListMerger() MergeOption {
 	return func(m *merger) {
@@ -120,4 +123,14 @@ func (mg *merger) mergeOverlay(m *overlayDocument) Container {
 		merged = mg.mergeContainers(merged, m.overlays[name])
 	}
 	return merged
+}
+
+func coalesce(nodes ...Node) Node {
+	slices.Reverse(nodes)
+	for _, node := range nodes {
+		if hasValue(node) {
+			return node
+		}
+	}
+	return nilLeaf
 }

--- a/dom/merge_test.go
+++ b/dom/merge_test.go
@@ -18,6 +18,7 @@ package dom
 
 import (
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -70,4 +71,33 @@ func TestMergeContainerFromTwoLists(t *testing.T) {
 	m.init()
 	l := m.mergeListsMeld(ListNode(c1), ListNode(c2))
 	assert.Equal(t, 1, l.Size())
+}
+
+func TestCoalesce(t *testing.T) {
+	assert.Equal(t, nilLeaf, coalesce(nilLeaf))
+	assert.Equal(t, 123, coalesce(nilLeaf,
+		LeafNode(123), nilLeaf).(Leaf).Value())
+}
+
+func TestMergeOverrideLeafValue(t *testing.T) {
+	d1 := `
+---
+root:
+  sub1:
+    sub2:
+      leaf: 1
+`
+	d2 := `
+---
+root:
+  sub1:
+    sub2:
+      leaf: 2
+`
+	orig, err := b.FromReader(strings.NewReader(d1), DefaultYamlDecoder)
+	assert.NoError(t, err)
+	override, err := b.FromReader(strings.NewReader(d2), DefaultYamlDecoder)
+	assert.NoError(t, err)
+	result := orig.Merge(override)
+	assert.Equal(t, 2, result.Lookup("root.sub1.sub2.leaf").(Leaf).Value())
 }

--- a/dom/overlay.go
+++ b/dom/overlay.go
@@ -175,15 +175,6 @@ func hasValue(n Node) bool {
 	return true
 }
 
-func coalesce(nodes ...Node) Node {
-	for _, node := range nodes {
-		if hasValue(node) {
-			return node
-		}
-	}
-	return nilLeaf
-}
-
 func firstValidListItem(idx int, lists ...List) Node {
 	for _, list := range lists {
 		if list.Size() > idx {

--- a/dom/overlay_test.go
+++ b/dom/overlay_test.go
@@ -103,12 +103,6 @@ func TestLoadLookupList(t *testing.T) {
 	assert.Equal(t, "hello", n.(Leaf).Value())
 }
 
-func TestCoalesce(t *testing.T) {
-	assert.Equal(t, nilLeaf, coalesce(nilLeaf))
-	assert.Equal(t, 123, coalesce(nilLeaf,
-		LeafNode(123), nilLeaf).(Leaf).Value())
-}
-
 func TestFirstValidListItem(t *testing.T) {
 	assert.Equal(t, 456, firstValidListItem(1,
 		ListNode(),


### PR DESCRIPTION
Overriden value should be evaluated first, otherwise override will never work.
Move coalesce to appropriate merge*.go files and add unit test for this situation

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
