### PR TITLE
Pipeline: Add 'Log' operation

### DIFF
--- a/pipeline/log_op.go
+++ b/pipeline/log_op.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"fmt"
+)
+
+// LogOp just logs message to logger
+type LogOp struct {
+	Message string `yaml:"message"`
+}
+
+func (lo *LogOp) Do(ctx ActionContext) error {
+	ctx.Logger().Log(ctx.TemplateEngine().RenderLenient(lo.Message, ctx.Snapshot()))
+	return nil
+}
+
+func (lo *LogOp) String() string {
+	return fmt.Sprintf("Log[message=%s]", lo.Message)
+}
+
+func (lo *LogOp) CloneWith(ctx ActionContext) Action {
+	return &LogOp{
+		Message: ctx.TemplateEngine().RenderLenient(lo.Message, ctx.Snapshot()),
+	}
+}

--- a/pipeline/log_op_test.go
+++ b/pipeline/log_op_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"github.com/rkosegi/yaml-toolkit/dom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLogOpDo(t *testing.T) {
+	eo := &LogOp{}
+	assert.NoError(t, eo.Do(mockEmptyActCtx()))
+}
+
+func TestLogOpCloneWith(t *testing.T) {
+	eo := &LogOp{
+		Message: "Output format: {{ .Format }}",
+	}
+	assert.Contains(t, eo.String(), "Log[")
+	d := b.Container()
+	d.AddValue("Format", dom.LeafNode("toml"))
+	eo = eo.CloneWith(mockActCtx(d)).(*LogOp)
+	assert.Equal(t, "Output format: toml", eo.Message)
+}


### PR DESCRIPTION
This allows arbitrary messages to be logged during pipeline execution
