### PR TITLE
DOM: Add methods to convert DOM constructs to vanilla Go types.

### DIFF
--- a/dom/container.go
+++ b/dom/container.go
@@ -73,6 +73,10 @@ func (c *containerImpl) Flatten() map[string]Leaf {
 	return ret
 }
 
+func (c *containerImpl) AsMap() map[string]interface{} {
+	return encodeContainerFn(c)
+}
+
 func (c *containerImpl) Equals(node Node) bool {
 	if node == nil || !node.IsContainer() {
 		return false

--- a/dom/container_test.go
+++ b/dom/container_test.go
@@ -120,6 +120,16 @@ func TestLookup(t *testing.T) {
 	assert.Equal(t, "leaf1", doc.Lookup("level1.level2a.level3a").(Leaf).Value())
 }
 
+func TestContainerAsMap(t *testing.T) {
+	data, err := os.ReadFile("../testdata/doc1.yaml")
+	assert.Nil(t, err)
+	doc, err := b.FromReader(bytes.NewReader(data), DefaultYamlDecoder)
+	assert.Nil(t, err)
+	fm := doc.AsMap()
+	assert.Equal(t, 1, len(fm))
+	assert.NotNil(t, fm["level1"])
+}
+
 func TestFlatten(t *testing.T) {
 	data, err := os.ReadFile("../testdata/doc1.yaml")
 	assert.Nil(t, err)

--- a/dom/list.go
+++ b/dom/list.go
@@ -33,6 +33,10 @@ func (l *listImpl) Items() []Node {
 	return c
 }
 
+func (l *listImpl) AsSlice() []interface{} {
+	return encoderListFn(l)
+}
+
 func (l *listImpl) Size() int {
 	return len(l.items)
 }

--- a/dom/list_test.go
+++ b/dom/list_test.go
@@ -98,3 +98,12 @@ func TestListClone(t *testing.T) {
 	assert.Equal(t, l2.Items()[0], l.Items()[0])
 	assert.Equal(t, l2.Items()[1], l.Items()[1])
 }
+
+func TestListAsSlice(t *testing.T) {
+	l := ListNode(LeafNode(1), LeafNode(2), LeafNode(3))
+	l2 := l.AsSlice()
+	assert.Equal(t, 3, len(l2))
+	assert.Equal(t, 1, l2[0])
+	assert.Equal(t, 2, l2[1])
+	assert.Equal(t, 3, l2[2])
+}

--- a/dom/types.go
+++ b/dom/types.go
@@ -119,6 +119,10 @@ type List interface {
 	Size() int
 	// Items returns copy of slice of all nodes in this list
 	Items() []Node
+
+	// AsSlice converts recursively content of this List into []interface{}.
+	// Result consists from Go vanilla constructs only.
+	AsSlice() []interface{}
 }
 
 // NodeList is sequence of zero or more Nodes
@@ -136,6 +140,10 @@ type Container interface {
 	Lookup(path string) Node
 	// Flatten flattens this Container into list of leaves
 	Flatten() map[string]Leaf
+
+	// AsMap converts recursively content of this container into map[string]interface{}
+	// Result consists from Go vanilla constructs only and thus could be directly used in Go templates.
+	AsMap() map[string]interface{}
 	// Search finds all paths where Node's value is equal to given value according to provided SearchValueFunc.
 	// If no match is found, nil is returned.
 	Search(fn SearchValueFunc) []string


### PR DESCRIPTION
- Container => asMap() returns map[string]interface{}
- List => AsSlice() returns []interface{}
- Leaf => Value() returns interface{}

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
