### PR TITLE
DOM: Return self refernce on builder interfaces for builder chain support.

### DIFF
--- a/dom/container.go
+++ b/dom/container.go
@@ -204,8 +204,9 @@ func (c *containerBuilderImpl) AddList(name string) ListBuilder {
 	return lb
 }
 
-func (c *containerBuilderImpl) Remove(name string) {
+func (c *containerBuilderImpl) Remove(name string) ContainerBuilder {
 	delete(c.children, name)
+	return c
 }
 
 func (c *containerBuilderImpl) AddContainer(name string) ContainerBuilder {
@@ -242,8 +243,9 @@ func (c *containerBuilderImpl) add(name string, child Node) {
 	}
 }
 
-func (c *containerBuilderImpl) AddValue(name string, value Node) {
+func (c *containerBuilderImpl) AddValue(name string, value Node) ContainerBuilder {
 	c.add(name, value)
+	return c
 }
 
 func (c *containerBuilderImpl) addChild(parent ContainerBuilder, name string) ContainerBuilder {
@@ -276,15 +278,17 @@ func (c *containerBuilderImpl) ancestorOf(path string, create bool) (ContainerBu
 	return node, cp[len(cp)-1]
 }
 
-func (c *containerBuilderImpl) AddValueAt(path string, value Node) {
+func (c *containerBuilderImpl) AddValueAt(path string, value Node) ContainerBuilder {
 	node, p := c.ancestorOf(path, true)
 	node.AddValue(p, value)
+	return c
 }
 
-func (c *containerBuilderImpl) RemoveAt(path string) {
+func (c *containerBuilderImpl) RemoveAt(path string) ContainerBuilder {
 	if node, p := c.ancestorOf(path, false); node != nil {
 		node.Remove(p)
 	}
+	return c
 }
 
 type containerFactory struct {

--- a/dom/list.go
+++ b/dom/list.go
@@ -73,28 +73,32 @@ type listBuilderImpl struct {
 	listImpl
 }
 
-func (l *listBuilderImpl) Clear() {
+func (l *listBuilderImpl) Clear() ListBuilder {
 	l.items = []Node{}
+	return l
 }
 
-func (l *listBuilderImpl) Set(index uint, item Node) {
+func (l *listBuilderImpl) Set(index uint, item Node) ListBuilder {
 	for i := 0; i <= int(index); i++ {
 		if i > len(l.items)-1 {
 			l.Append(nilLeaf)
 		}
 	}
 	l.items[index] = item
+	return l
 }
 
-func (l *listBuilderImpl) MustSet(index uint, item Node) {
+func (l *listBuilderImpl) MustSet(index uint, item Node) ListBuilder {
 	if int(index) > len(l.items)-1 {
 		panic(fmt.Sprintf("index out of bounds: %d", index))
 	}
 	l.items[index] = item
+	return l
 }
 
-func (l *listBuilderImpl) Append(item Node) {
+func (l *listBuilderImpl) Append(item Node) ListBuilder {
 	l.items = append(l.items, item)
+	return l
 }
 
 func ListNode(items ...Node) ListBuilder {

--- a/dom/types.go
+++ b/dom/types.go
@@ -153,18 +153,18 @@ type Container interface {
 type ContainerBuilder interface {
 	Container
 	// AddValue adds Node value into this Container
-	AddValue(name string, value Node)
+	AddValue(name string, value Node) ContainerBuilder
 	// AddValueAt adds Leaf value into this Container at given path.
 	// Child nodes are creates as needed.
-	AddValueAt(path string, value Node)
+	AddValueAt(path string, value Node) ContainerBuilder
 	// AddContainer adds child Container into this Container
 	AddContainer(name string) ContainerBuilder
 	// AddList adds child List into this Container
 	AddList(name string) ListBuilder
 	// Remove removes direct child Node.
-	Remove(name string)
+	Remove(name string) ContainerBuilder
 	// RemoveAt removes child Node at given path.
-	RemoveAt(path string)
+	RemoveAt(path string) ContainerBuilder
 	// Walk walks whole document tree, visiting every node
 	Walk(fn WalkFn)
 	// Merge creates new Container instance and merge current Container with other into it.
@@ -217,13 +217,13 @@ type Coordinates []Coordinate
 type ListBuilder interface {
 	List
 	// Clear sets items to empty slice
-	Clear()
+	Clear() ListBuilder
 	// Set sets item at given index. Items are allocated and set to nil Leaf as necessary.
-	Set(uint, Node)
+	Set(uint, Node) ListBuilder
 	// MustSet sets item at given index. Panics if index is out of bounds.
-	MustSet(uint, Node)
+	MustSet(uint, Node) ListBuilder
 	// Append adds new item at the end of slice
-	Append(Node)
+	Append(Node) ListBuilder
 }
 
 // MergeOption is function used to customize merger behavior


### PR DESCRIPTION
It make sense to support chaining in some of builder methods, eg:

```go
cb := Builder().Container()
cb.AddValue("leaf1, LeafNode(10)).Remove("old-leaf") ....
```

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
