### PR TITLE
DOM: Deprecate ContainerFactory#FromAny() method

### DIFF
--- a/dom/types.go
+++ b/dom/types.go
@@ -199,7 +199,8 @@ type ContainerFactory interface {
 	// FromProperties is similar to FromMap except that keys are parsed into path before inserting into ContainerBuilder
 	FromProperties(in map[string]interface{}) ContainerBuilder
 	// FromAny creates ContainerBuilder from any object. Any error encountered in process will result in panic.
-	// This method uses YAML codec internally to perform translation between raw interface and map
+	// This method uses YAML codec internally to perform translation between raw interface and map.
+	// Deprecated, do not use. Same can be simply achieved by various ways by caller himself.
 	FromAny(v interface{}) ContainerBuilder
 }
 


### PR DESCRIPTION
This should never be part of this interface.
Its implementation is very opiononated and can be achieved by various ways
by caller. Deprecate and remove it later.

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
