### PR TITLE
Pipeline: Allow any dom.Node to be argument in forEach op when query is used

### DIFF
--- a/pipeline/foreach_op.go
+++ b/pipeline/foreach_op.go
@@ -58,10 +58,8 @@ func (fea *ForEachOp) Do(ctx ActionContext) error {
 	} else if nonEmpty(fea.Query) {
 		if n := ctx.Data().Lookup(*fea.Query); n != nil && n.IsList() {
 			for _, item := range n.(dom.List).Items() {
-				if x, ok := item.(dom.Leaf); ok {
-					if err := fea.performWithItem(ctx, x); err != nil {
-						return err
-					}
+				if err := fea.performWithItem(ctx, item); err != nil {
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
