### PR TITLE
Pipeline: refactor pipeline tests - remove deprecated mock context functions

### DIFF
--- a/pipeline/abort_op_test.go
+++ b/pipeline/abort_op_test.go
@@ -36,7 +36,7 @@ func TestAbortOpCloneWith(t *testing.T) {
 	}
 	d := b.Container()
 	d.AddValue("Format", dom.LeafNode("toml"))
-	eo = eo.CloneWith(mockActCtx(d)).(*AbortOp)
+	eo = eo.CloneWith(newMockActBuilder().data(d).build()).(*AbortOp)
 	assert.Equal(t, "Unsupported format: toml", eo.Message)
 }
 

--- a/pipeline/define_op_test.go
+++ b/pipeline/define_op_test.go
@@ -66,7 +66,7 @@ func TestForDefCall(t *testing.T) {
 		},
 	}
 
-	ctx := mockActCtxLog(t)
+	ctx := newMockActBuilder().testLogger(t).build()
 	err := ctx.Executor().Execute(root)
 	assert.NoError(t, err)
 }

--- a/pipeline/env_op_test.go
+++ b/pipeline/env_op_test.go
@@ -44,7 +44,7 @@ func TestEnvOpDo(t *testing.T) {
 		Exclude: createRePtr("XYZ"),
 	}
 	d := b.Container()
-	err := eo.Do(mockActCtx(d))
+	err := eo.Do(newMockActBuilder().data(d).build())
 	assert.NoError(t, err)
 	assert.Equal(t, "val1", d.Lookup("Sub.Env.MOCK1").(dom.Leaf).Value())
 	assert.Equal(t, "val2", d.Lookup("Sub.Env.MOCK2").(dom.Leaf).Value())
@@ -57,6 +57,6 @@ func TestEnvOpCloneWith(t *testing.T) {
 	}
 	d := b.Container()
 	d.AddValue("NewPath", dom.LeafNode("root"))
-	eo = eo.CloneWith(mockActCtx(d)).(*EnvOp)
+	eo = eo.CloneWith(newMockActBuilder().data(d).build()).(*EnvOp)
 	assert.Equal(t, "root", eo.Path)
 }

--- a/pipeline/exec_op_test.go
+++ b/pipeline/exec_op_test.go
@@ -59,7 +59,7 @@ func TestExecOpDo(t *testing.T) {
 		SaveExitCodeTo: strPointer("Res"),
 	}
 	d := b.Container()
-	ctx := mockActCtx(d)
+	ctx := newMockActBuilder().data(d).build()
 	assert.NoError(t, eo.Do(ctx))
 	assert.Equal(t, 3, d.Lookup("Res").(dom.Leaf).Value())
 	eo = &ExecOp{
@@ -78,6 +78,6 @@ func TestExecOpCloneWith(t *testing.T) {
 	}
 	d := b.Container()
 	d.AddValue("Shell", dom.LeafNode("/bin/bash"))
-	eo = eo.CloneWith(mockActCtx(d)).(*ExecOp)
+	eo = eo.CloneWith(newMockActBuilder().data(d).build()).(*ExecOp)
 	assert.Equal(t, "/bin/bash", eo.Program)
 }

--- a/pipeline/export_op_test.go
+++ b/pipeline/export_op_test.go
@@ -44,7 +44,7 @@ func TestExportOpDo(t *testing.T) {
 	assert.Contains(t, eo.String(), f.Name())
 	d := b.Container()
 	d.AddValueAt("root.sub1.sub2", dom.LeafNode(123))
-	err = eo.Do(mockActCtx(d))
+	err = eo.Do(newMockActBuilder().data(d).build())
 	assert.NoError(t, err)
 	fi, err := os.Stat(f.Name())
 	assert.NotNil(t, fi)
@@ -55,7 +55,7 @@ func TestExportOpDo(t *testing.T) {
 		Path:   "root.sub1.sub2",
 		Format: OutputFormatText,
 	}
-	err = eo.Do(mockActCtx(d))
+	err = eo.Do(newMockActBuilder().data(d).build())
 	assert.NoError(t, err)
 
 	eo = &ExportOp{
@@ -63,7 +63,7 @@ func TestExportOpDo(t *testing.T) {
 		Path:   "root.sub1",
 		Format: OutputFormatText,
 	}
-	err = eo.Do(mockActCtx(d))
+	err = eo.Do(newMockActBuilder().data(d).build())
 	assert.Error(t, err)
 }
 
@@ -106,7 +106,7 @@ func TestExportOpCloneWith(t *testing.T) {
 	d := b.Container()
 	d.AddValueAt("Format", dom.LeafNode("yaml"))
 	d.AddValueAt("Sub", dom.LeafNode("sub20"))
-	eo = eo.CloneWith(mockActCtx(d)).(*ExportOp)
+	eo = eo.CloneWith(newMockActBuilder().data(d).build()).(*ExportOp)
 	assert.Equal(t, "root.sub10.sub20", eo.Path)
 	assert.Equal(t, OutputFormatYaml, eo.Format)
 	assert.Equal(t, "/tmp/out.yaml", eo.File)

--- a/pipeline/ext_op_test.go
+++ b/pipeline/ext_op_test.go
@@ -33,13 +33,13 @@ func (n *noopOp) CloneWith(_ ActionContext) Action { return &noopOp{} }
 func TestExtOpDo(t *testing.T) {
 	var ex *ExtOp
 	d := b.Container()
-	ctx := mockActCtxExt(d, map[string]Action{
+	ctx := newMockActBuilder().ext(map[string]Action{
 		"dummyfn": &SetOp{
 			Data: map[string]interface{}{
 				"X": 123,
 			},
 		},
-	})
+	}).data(d).build()
 	ex = &ExtOp{
 		Function: "dummyfn",
 	}

--- a/pipeline/foreach_op_test.go
+++ b/pipeline/foreach_op_test.go
@@ -74,7 +74,7 @@ func TestForeachStringItem(t *testing.T) {
 		},
 	}
 	d := b.Container()
-	err := op.Do(mockActCtx(d))
+	err := op.Do(newMockActBuilder().data(d).build())
 	assert.NoError(t, err)
 	assert.Equal(t, "abc", d.Lookup("a.X").(dom.Leaf).Value())
 	assert.Equal(t, "abc", d.Lookup("b.X").(dom.Leaf).Value())
@@ -93,7 +93,7 @@ func TestForeachStringItemChildError(t *testing.T) {
 		},
 	}
 	d := b.Container()
-	err := op.Do(mockActCtx(d))
+	err := op.Do(newMockActBuilder().data(d).build())
 	assert.Error(t, err)
 }
 
@@ -127,7 +127,7 @@ func TestForeachQuery(t *testing.T) {
 				},
 			},
 		}
-		assert.Error(t, op.Do(mockActCtx(data)))
+		assert.Error(t, op.Do(newMockActBuilder().data(data).build()))
 	}
 	for _, tc := range []testcase{
 		{
@@ -170,7 +170,7 @@ func TestForeachQuery(t *testing.T) {
 				},
 			},
 		}
-		err = op.Do(mockActCtx(data))
+		err = op.Do(newMockActBuilder().data(data).build())
 		assert.NoError(t, err)
 		tc.validateFn(data)
 	}
@@ -190,7 +190,7 @@ func TestForeachGlob(t *testing.T) {
 		},
 	}
 	d := b.Container()
-	err := op.Do(mockActCtx(d))
+	err := op.Do(newMockActBuilder().data(d).build())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(d.Lookup("import.files").(dom.Container).Children()))
 }
@@ -214,7 +214,7 @@ func TestForeachActionSpec(t *testing.T) {
 			},
 		},
 	}
-	err = op.Do(mockActCtxLog(t))
+	err = op.Do(newMockActBuilder().testLogger(t).build())
 	assert.NoError(t, err)
 
 	op = &ForEachOp{
@@ -234,7 +234,7 @@ func TestForeachActionSpec(t *testing.T) {
 	}
 	d := b.Container()
 	d.AddValue("X", dom.LeafNode(100))
-	err = op.Do(mockActCtx(d))
+	err = op.Do(newMockActBuilder().data(d).build())
 	assert.NoError(t, err)
 	assert.Equal(t, "103", d.Lookup("X").(dom.Leaf).Value())
 }
@@ -250,7 +250,7 @@ func TestForeachGlobChildError(t *testing.T) {
 			},
 		},
 	}
-	err := op.Do(mockActCtxLog(t))
+	err := op.Do(newMockActBuilder().testLogger(t).build())
 	assert.Error(t, err)
 }
 
@@ -268,6 +268,6 @@ func TestForeachGlobInvalid(t *testing.T) {
 		},
 	}
 	d := b.Container()
-	err := op.Do(mockActCtx(d))
+	err := op.Do(newMockActBuilder().data(d).build())
 	assert.Error(t, err)
 }

--- a/pipeline/log_op_test.go
+++ b/pipeline/log_op_test.go
@@ -35,6 +35,6 @@ func TestLogOpCloneWith(t *testing.T) {
 	assert.Contains(t, eo.String(), "Log[")
 	d := b.Container()
 	d.AddValue("Format", dom.LeafNode("toml"))
-	eo = eo.CloneWith(mockActCtx(d)).(*LogOp)
+	eo = eo.CloneWith(newMockActBuilder().data(d).build()).(*LogOp)
 	assert.Equal(t, "Output format: toml", eo.Message)
 }

--- a/pipeline/loop_op_test.go
+++ b/pipeline/loop_op_test.go
@@ -77,7 +77,7 @@ func TestLoopOpSimple(t *testing.T) {
 	}
 
 	d := b.Container()
-	ac := mockActCtx(d)
+	ac := newMockActBuilder().data(d).build()
 	err := op.Do(ac)
 	assert.NoError(t, err)
 	assert.Equal(t, "10", d.Lookup("i").(dom.Leaf).Value())

--- a/pipeline/op_spec_test.go
+++ b/pipeline/op_spec_test.go
@@ -93,11 +93,11 @@ func TestOpSpecCloneWith(t *testing.T) {
 		},
 	}
 
-	a := o.CloneWith(mockActCtx(b.FromMap(map[string]interface{}{
+	a := o.CloneWith(newMockActBuilder().data(b.FromMap(map[string]interface{}{
 		"Path":  "root.sub2",
 		"Path3": "/root/sub3",
 		"Shell": "/bin/bash",
-	}))).(OpSpec)
+	})).build()).(OpSpec)
 	t.Log(a.String())
 	assert.Equal(t, "root.sub2", a.Set.Path)
 	assert.Equal(t, "root.sub2", a.Import.Path)

--- a/pipeline/utils_test.go
+++ b/pipeline/utils_test.go
@@ -85,21 +85,6 @@ func mockEmptyActCtx() ActionContext {
 	return newMockActBuilder().build()
 }
 
-// deprecated
-func mockActCtx(data dom.ContainerBuilder) ActionContext {
-	return newMockActBuilder().data(data).build()
-}
-
-// deprecated
-func mockActCtxLog(t *testing.T) ActionContext {
-	return newMockActBuilder().testLogger(t).build()
-}
-
-// deprecated
-func mockActCtxExt(data dom.ContainerBuilder, ea map[string]Action) ActionContext {
-	return newMockActBuilder().data(data).ext(ea).build()
-}
-
 func removeFilesLater(t *testing.T, files ...*os.File) {
 	t.Cleanup(func() {
 		for _, f := range files {
@@ -154,7 +139,7 @@ func TestSafeRenderStrPointer(t *testing.T) {
 	d := b.FromMap(map[string]interface{}{
 		"X": "abc",
 	})
-	c := mockActCtx(d)
+	c := newMockActBuilder().data(d).build()
 	assert.Equal(t, "abc", *safeRenderStrPointer(&s, c.TemplateEngine(), c.Snapshot()))
 }
 


### PR DESCRIPTION
Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
