### PR TITLE
Pipeline: ext functions should be created with factory

### DIFF
--- a/pipeline/executor.go
+++ b/pipeline/executor.go
@@ -26,7 +26,7 @@ var (
 )
 
 type ext struct {
-	ea map[string]Action
+	ea map[string]ActionFactory
 	cm map[string]ActionSpec
 }
 
@@ -39,11 +39,11 @@ func (e *ext) Get(name string) (ActionSpec, bool) {
 	return r, ok
 }
 
-func (e *ext) AddAction(name string, action Action) {
+func (e *ext) AddAction(name string, action ActionFactory) {
 	e.ea[name] = action
 }
 
-func (e *ext) GetAction(name string) (Action, bool) {
+func (e *ext) GetAction(name string) (ActionFactory, bool) {
 	r, ok := e.ea[name]
 	return r, ok
 }
@@ -64,8 +64,8 @@ type actContext struct {
 type ExtInterface interface {
 	Define(string, ActionSpec)
 	Get(string) (ActionSpec, bool)
-	AddAction(string, Action)
-	GetAction(string) (Action, bool)
+	AddAction(string, ActionFactory)
+	GetAction(string) (ActionFactory, bool)
 }
 
 func (ac actContext) Action() Action                 { return ac.c }
@@ -131,7 +131,7 @@ func WithTemplateEngine(t TemplateEngine) Opt {
 	}
 }
 
-func WithExtActions(m map[string]Action) Opt {
+func WithExtActions(m map[string]ActionFactory) Opt {
 	return func(p *exec) {
 		for k, v := range m {
 			p.AddAction(k, v)
@@ -145,13 +145,13 @@ var defOpts = []Opt{
 	WithTemplateEngine(&templateEngine{
 		fm: sprig.TxtFuncMap(),
 	}),
-	WithExtActions(make(map[string]Action)),
+	WithExtActions(make(map[string]ActionFactory)),
 }
 
 func New(opts ...Opt) Executor {
 	p := &exec{
 		ext: &ext{
-			ea: make(map[string]Action),
+			ea: make(map[string]ActionFactory),
 			cm: make(map[string]ActionSpec),
 		},
 	}

--- a/pipeline/executor_test.go
+++ b/pipeline/executor_test.go
@@ -27,6 +27,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type dummyActFactory struct {
+	act Action
+}
+
+func (d *dummyActFactory) NewForArgs(_ map[string]interface{}) Action {
+	return d.act
+}
+
 var dummyExec = New().(*exec)
 
 func newTestExec(d dom.ContainerBuilder) *exec {
@@ -335,8 +343,8 @@ func TestExecuteForEachFileGlob(t *testing.T) {
 			ForEach: fe,
 		},
 	}
-	ex.ea = map[string]Action{
-		"noop": &noopOp{},
+	ex.ea = map[string]ActionFactory{
+		"noop": &dummyActFactory{act: &noopOp{}},
 	}
 	assert.NoError(t, ex.Execute(ss))
 	assert.Equal(t, 2, len(gd.Lookup("import.files").(dom.Container).Children()))

--- a/pipeline/ext_op.go
+++ b/pipeline/ext_op.go
@@ -21,6 +21,8 @@ import "fmt"
 type ExtOp struct {
 	// Function is name of function that was registered with Executor
 	Function string `yaml:"func"`
+	// Args holds arguments to be passed to function, if it implements ArgsSetter.
+	Args map[string]interface{} `yaml:"args"`
 }
 
 func (e *ExtOp) String() string {
@@ -29,7 +31,7 @@ func (e *ExtOp) String() string {
 
 func (e *ExtOp) Do(ctx ActionContext) error {
 	if fn, ok := ctx.Ext().GetAction(e.Function); ok {
-		return ctx.Executor().Execute(fn)
+		return ctx.Executor().Execute(fn.NewForArgs(e.Args))
 	}
 	return fmt.Errorf("no such function: %s", e.Function)
 }

--- a/pipeline/ext_op_test.go
+++ b/pipeline/ext_op_test.go
@@ -33,10 +33,12 @@ func (n *noopOp) CloneWith(_ ActionContext) Action { return &noopOp{} }
 func TestExtOpDo(t *testing.T) {
 	var ex *ExtOp
 	d := b.Container()
-	ctx := newMockActBuilder().ext(map[string]Action{
-		"dummyfn": &SetOp{
-			Data: map[string]interface{}{
-				"X": 123,
+	ctx := newMockActBuilder().ext(map[string]ActionFactory{
+		"dummyfn": &dummyActFactory{
+			act: &SetOp{
+				Data: map[string]interface{}{
+					"X": 123,
+				},
 			},
 		},
 	}).data(d).build()

--- a/pipeline/types.go
+++ b/pipeline/types.go
@@ -102,5 +102,17 @@ type Cloneable interface {
 	CloneWith(ctx ActionContext) Action
 }
 
+// ActionFactory can be used to create instances of Action
+type ActionFactory interface {
+	// NewForArgs creates new instance of Action for given set of arguments.
+	NewForArgs(args map[string]interface{}) Action
+}
+
+// ArgsSetter is implemented by ext Action if it wishes to receive arguments.
+type ArgsSetter interface {
+	// SetArgs sets arguments from map
+	SetArgs(args map[string]interface{})
+}
+
 // ChildActions is map of named actions that are executed as a part of parent action
 type ChildActions map[string]ActionSpec

--- a/pipeline/utils_test.go
+++ b/pipeline/utils_test.go
@@ -61,7 +61,7 @@ type mockActCtxBuilder struct {
 	opts []Opt
 }
 
-func (mcb *mockActCtxBuilder) ext(ea map[string]Action) *mockActCtxBuilder {
+func (mcb *mockActCtxBuilder) ext(ea map[string]ActionFactory) *mockActCtxBuilder {
 	mcb.opts = append(mcb.opts, WithExtActions(ea))
 	return mcb
 }


### PR DESCRIPTION
This allows to pass arbitrary arguments to function

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
