### PR TITLE
Pipeline: introduce AnyVal so patch op can handle different value types

### DIFF
--- a/pipeline/executor_test.go
+++ b/pipeline/executor_test.go
@@ -209,7 +209,7 @@ func TestExecutePatch(t *testing.T) {
 			Patch: &PatchOp{
 				Op:    patch.OpAdd,
 				Path:  "/root",
-				Value: map[string]interface{}{"leaf": "abcd"},
+				Value: anyValFromMap(map[string]interface{}{"leaf": "abcd"}),
 			},
 		},
 	}))

--- a/pipeline/patch_op.go
+++ b/pipeline/patch_op.go
@@ -25,10 +25,10 @@ import (
 // PatchOp performs RFC6902-style patch on global data document.
 // Check patch package for more details
 type PatchOp struct {
-	Op    patch.Op               `yaml:"op"`
-	From  string                 `yaml:"from,omitempty" clone:"template"`
-	Path  string                 `yaml:"path" clone:"template"`
-	Value map[string]interface{} `yaml:"value,omitempty"`
+	Op    patch.Op `yaml:"op"`
+	From  string   `yaml:"from,omitempty" clone:"template"`
+	Path  string   `yaml:"path" clone:"template"`
+	Value *AnyVal  `yaml:"value,omitempty"`
 }
 
 func (ps *PatchOp) String() string {
@@ -44,7 +44,9 @@ func (ps *PatchOp) Do(ctx ActionContext) error {
 		return err
 	}
 	oo.Path = path
-	oo.Value = b.FromMap(ps.Value)
+	if ps.Value != nil {
+		oo.Value = ps.Value.Value()
+	}
 	if len(ps.From) > 0 {
 		from, err := patch.ParsePath(ps.From)
 		if err != nil {

--- a/pipeline/patch_op_test.go
+++ b/pipeline/patch_op_test.go
@@ -41,9 +41,9 @@ func TestExecutePatchOp(t *testing.T) {
 	ps = PatchOp{
 		Op:   patch.OpReplace,
 		Path: "/root/sub1",
-		Value: map[string]interface{}{
+		Value: anyValFromMap(map[string]interface{}{
 			"leaf2": "xyz",
-		},
+		}),
 	}
 	assert.NoError(t, New(WithData(gd)).Execute(&ps))
 	assert.Equal(t, "xyz", gd.Lookup("root.sub1.leaf2").(dom.Leaf).Value())
@@ -67,4 +67,22 @@ func TestExecutePatchOp(t *testing.T) {
 		Path: "/root/sub2",
 	}
 	assert.Error(t, New(WithData(gd)).Execute(&ps))
+}
+
+func TestPatchOpAddValue(t *testing.T) {
+	var (
+		ps PatchOp
+		gd dom.ContainerBuilder
+	)
+	gd = b.Container()
+	gd.AddValueAt("root.sub.leaf1", dom.LeafNode("123"))
+	ps = PatchOp{
+		Op:    patch.OpAdd,
+		Path:  "/root/sub/leaf2",
+		Value: &AnyVal{v: dom.LeafNode(456)},
+	}
+	assert.NoError(t, New(WithData(gd)).Execute(&ps))
+	m := gd.AsMap()
+	assert.Equal(t, "123", m["root"].(map[string]interface{})["sub"].(map[string]interface{})["leaf1"].(string))
+	assert.Equal(t, 456, m["root"].(map[string]interface{})["sub"].(map[string]interface{})["leaf2"].(int))
 }

--- a/pipeline/types.go
+++ b/pipeline/types.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/rkosegi/yaml-toolkit/dom"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -112,6 +113,25 @@ type ActionFactory interface {
 type ArgsSetter interface {
 	// SetArgs sets arguments from map
 	SetArgs(args map[string]interface{})
+}
+
+// AnyVal can represent any DOM value (leaf, list, container)
+type AnyVal struct {
+	v dom.Node
+}
+
+func (pv *AnyVal) UnmarshalYAML(node *yaml.Node) error {
+	pv.v = dom.YamlNodeDecoder()(node)
+	return nil
+}
+
+// Value get actual value
+func (pv *AnyVal) Value() dom.Node {
+	return pv.v
+}
+
+func anyValFromMap(m map[string]interface{}) *AnyVal {
+	return &AnyVal{v: dom.DefaultNodeDecoderFn(m)}
 }
 
 // ChildActions is map of named actions that are executed as a part of parent action

--- a/pipeline/types_test.go
+++ b/pipeline/types_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2025 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/rkosegi/yaml-toolkit/dom"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestAnyVal(t *testing.T) {
+	type testStruct struct {
+		V *AnyVal `yaml:"v,omitempty"`
+	}
+	var (
+		err error
+		ts  testStruct
+		// n  *yaml.Node
+	)
+	d1 := `v: 123`
+	err = yaml.Unmarshal([]byte(d1), &ts)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", ts.V.Value().(dom.Leaf).Value())
+	d2 := `
+v:
+  a: 123
+  b: XYZ
+`
+	err = yaml.Unmarshal([]byte(d2), &ts)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", ts.V.Value().(dom.Container).Child("a").(dom.Leaf).Value())
+}


### PR DESCRIPTION
Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
