### PR TITLE
DOM: Add Seal() method to enforce immutability of builder objects

### DIFF
--- a/dom/container.go
+++ b/dom/container.go
@@ -181,6 +181,10 @@ type containerBuilderImpl struct {
 	containerImpl
 }
 
+func (c *containerBuilderImpl) Seal() Container {
+	return &c.containerImpl
+}
+
 func (c *containerBuilderImpl) Walk(fn WalkFn) {
 	c.ensureChildren()
 	for k, v := range c.children {

--- a/dom/container_test.go
+++ b/dom/container_test.go
@@ -327,3 +327,10 @@ func TestMergeContainers(t *testing.T) {
 	assert.Equal(t, 4, len(d.Lookup("l1").(Container).Children()))
 	assert.Equal(t, "abc", d.Lookup("l1.l2b").(Leaf).Value())
 }
+
+func TestContainerBuilderSeal(t *testing.T) {
+	a := b.Container()
+	c := a.Seal()
+	_, isType := c.(ContainerBuilder)
+	assert.False(t, isType)
+}

--- a/dom/list.go
+++ b/dom/list.go
@@ -101,6 +101,10 @@ func (l *listBuilderImpl) Append(item Node) ListBuilder {
 	return l
 }
 
+func (l *listBuilderImpl) Seal() List {
+	return &l.listImpl
+}
+
 func ListNode(items ...Node) ListBuilder {
 	l := &listBuilderImpl{}
 	for _, item := range items {

--- a/dom/list_test.go
+++ b/dom/list_test.go
@@ -108,3 +108,10 @@ func TestListAsSlice(t *testing.T) {
 	assert.Equal(t, 2, l2[1])
 	assert.Equal(t, 3, l2[2])
 }
+
+func TestListBuilderSeal(t *testing.T) {
+	a := ListNode()
+	c := a.Seal()
+	_, isType := c.(ListBuilder)
+	assert.False(t, isType)
+}

--- a/dom/types.go
+++ b/dom/types.go
@@ -177,6 +177,8 @@ type ContainerBuilder interface {
 	Walk(fn WalkFn)
 	// Merge creates new Container instance and merge current Container with other into it.
 	Merge(other Container, opts ...MergeOption) ContainerBuilder
+	// Seal seals the builder so that returning object will be immutable
+	Seal() Container
 }
 
 type WalkFn func(path string, parent ContainerBuilder, node Node) bool
@@ -229,6 +231,8 @@ type ListBuilder interface {
 	MustSet(uint, Node) ListBuilder
 	// Append adds new item at the end of slice
 	Append(Node) ListBuilder
+	// Seal seals the builder so that returning object will be immutable
+	Seal() List
 }
 
 // MergeOption is function used to customize merger behavior


### PR DESCRIPTION
Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
