### PR TITLE
Pipeline: introduce specialized types for maps

### DIFF
--- a/pipeline/types.go
+++ b/pipeline/types.go
@@ -228,3 +228,27 @@ func anyValFromMap(m map[string]interface{}) *AnyVal {
 
 // ChildActions is map of named actions that are executed as a part of parent action
 type ChildActions map[string]ActionSpec
+
+// StrKeysStrValues is key-value map with strings.
+type StrKeysStrValues map[string]string
+
+// AsAnyValuesMap converts this map to StrKeysAnyValues suitable for template related operations.
+func (skv StrKeysStrValues) AsAnyValuesMap() StrKeysAnyValues {
+	out := make(StrKeysAnyValues, len(skv))
+	for k, v := range skv {
+		out[k] = v
+	}
+	return out
+}
+
+// RenderValues renders values of this map using provided TemplateEngine and data.
+func (skv StrKeysStrValues) RenderValues(te TemplateEngine, data StrKeysAnyValues) StrKeysStrValues {
+	out := make(map[string]string, len(skv))
+	for k, v := range skv {
+		out[k] = te.RenderLenient(v, data)
+	}
+	return out
+}
+
+// StrKeysAnyValues is a map with string keys and values with any type
+type StrKeysAnyValues map[string]any

--- a/pipeline/types_test.go
+++ b/pipeline/types_test.go
@@ -19,6 +19,7 @@ package pipeline
 import (
 	"testing"
 
+	sprig "github.com/go-task/slim-sprig/v3"
 	"github.com/rkosegi/yaml-toolkit/dom"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
@@ -103,4 +104,24 @@ func TestValOrRefString(t *testing.T) {
 	assert.Equal(t, "[Val=A]", (&ValOrRef{Val: "A"}).String())
 	assert.Equal(t, "[Ref=a.b]", (&ValOrRef{Ref: "a.b"}).String())
 	assert.Equal(t, "[Ref=x.y,Val=X]", (&ValOrRef{Val: "X", Ref: "x.y"}).String())
+}
+
+func TestStrKeyValuesAsAnyValuesMap(t *testing.T) {
+	in := StrKeysStrValues{
+		"A": "abc",
+	}
+	out := in.AsAnyValuesMap()
+	assert.Equal(t, "abc", out["A"])
+}
+
+func TestStrKeyValuesRenderValues(t *testing.T) {
+	in := StrKeysStrValues{
+		"A": `{{ printf "%s %s" .X .Y }}`,
+	}
+	te := &templateEngine{fm: sprig.FuncMap()}
+	out := in.RenderValues(te, StrKeysAnyValues{
+		"X": "Hello",
+		"Y": "World",
+	})
+	assert.Equal(t, "Hello World", out["A"])
 }


### PR DESCRIPTION
These could be used later on to optimize handling of operation arguments

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
