### PR TITLE
🚸 Path: implement fmt.Stringer in Path

### DIFF
--- a/path/builder.go
+++ b/path/builder.go
@@ -20,10 +20,10 @@ type builder struct {
 	components []Component
 }
 
-var emptyPath = &path{}
+var emptyPath = buildPath([]Component{})
 
 func (b *builder) Build() Path {
-	return &path{components: b.components}
+	return buildPath(b.components)
 }
 
 func (b *builder) Append(c Component) Builder {
@@ -31,6 +31,12 @@ func (b *builder) Append(c Component) Builder {
 	copy(cs, b.components)
 	cs = append(b.components, c)
 	return &builder{components: cs}
+}
+
+func buildPath(pc []Component) Path {
+	p := &path{components: pc}
+	p.s = p.buildString()
+	return p
 }
 
 // NewBuilder creates new Builder
@@ -49,7 +55,7 @@ func ParentOf(p Path) Path {
 	default:
 		c := make([]Component, len(p.(*path).components)-1)
 		copy(c, p.(*path).components[:len(p.(*path).components)-1])
-		return &path{components: c}
+		return buildPath(c)
 	}
 }
 
@@ -58,5 +64,5 @@ func ChildOf(parent Path, cps ...Component) Path {
 	cs := make([]Component, len(parent.(*path).components))
 	copy(cs, parent.(*path).components)
 	cs = append(cs, cps...)
-	return &path{components: cs}
+	return buildPath(cs)
 }

--- a/path/builder_test.go
+++ b/path/builder_test.go
@@ -63,3 +63,26 @@ func TestChildOf(t *testing.T) {
 	assert.Len(t, np.Components(), 3)
 	assert.Equal(t, "c", np.Last().Value())
 }
+
+func TestPathString(t *testing.T) {
+	type testCase struct {
+		exp string
+		p   Path
+	}
+	for _, tc := range []testCase{
+		{
+			exp: "[]",
+			p:   NewBuilder().Build(),
+		},
+		{
+			exp: `["a","b"]`,
+			p:   NewBuilder().Append(Simple("a")).Append(Simple("b")).Build(),
+		},
+		{
+			exp: `["a",0,3]`,
+			p:   NewBuilder().Append(Simple("a")).Append(Numeric(0)).Append(Numeric(3)).Build(),
+		},
+	} {
+		assert.Equal(t, tc.exp, tc.p.String())
+	}
+}

--- a/path/path.go
+++ b/path/path.go
@@ -16,10 +16,16 @@ limitations under the License.
 
 package path
 
-import "strconv"
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+)
 
 type path struct {
 	components []Component
+	s          string
 }
 
 func (p path) Last() Component {
@@ -37,6 +43,30 @@ func (p path) Components() []Component {
 	c := make([]Component, len(p.components))
 	copy(c, p.components)
 	return c
+}
+
+func (p path) buildString() string {
+	pcs := len(p.components)
+	if pcs == 0 {
+		return "[]"
+	}
+	var r []interface{}
+	for i := 0; i < pcs; i++ {
+		if p.components[i].IsNumeric() {
+			r = append(r, p.components[i].NumericValue())
+		} else {
+			r = append(r, p.components[i].Value())
+		}
+	}
+	// maybe use MarshalJSON() here?
+	var out bytes.Buffer
+	_ = json.NewEncoder(&out).Encode(r)
+	return strings.TrimSpace(out.String())
+}
+
+// String returns string representation of this path, that can be used as a key into map.
+func (p path) String() string {
+	return p.s
 }
 
 func AfterLast() Component {

--- a/path/types.go
+++ b/path/types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package path
 
+import "fmt"
+
 // Builder provides convenient way to construct Path using fluent builder pattern.
 type Builder interface {
 	// Append adds path component to the end of path.
@@ -45,6 +47,7 @@ type Component interface {
 }
 
 type Path interface {
+	fmt.Stringer
 	// Components returns copy of path components in this path
 	Components() []Component
 


### PR DESCRIPTION
This allows to use Path indirectly as a key in map.

Format of actual string representation should not be relied upon,
since it can change in future. It's only guaranteed that its value
uniquely identifies Node within the Container.

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
