### PR TITLE
🚸 DOM: Introduce Get(index) on list

### DIFF
--- a/diff/apply_test.go
+++ b/diff/apply_test.go
@@ -70,7 +70,7 @@ list1:
 			Value: "abc",
 		},
 	})
-	assert.True(t, doc.Child("list1").(dom.List).Items()[1].IsList())
+	assert.True(t, doc.Child("list1").AsList().Get(1).IsList())
 }
 
 func TestApplyNoop(t *testing.T) {

--- a/dom/codec_test.go
+++ b/dom/codec_test.go
@@ -45,7 +45,7 @@ root:
 		Child("list1").AsList().Size())
 	assert.Equal(t, "123", dn.AsContainer().
 		Child("root").AsContainer().
-		Child("list1").AsList().Items()[0].AsContainer().
+		Child("list1").AsList().Get(0).AsContainer().
 		Child("prop2").AsLeaf().Value())
 
 	assert.Nil(t, decodeYamlNode(&yaml.Node{

--- a/dom/container.go
+++ b/dom/container.go
@@ -114,7 +114,7 @@ func (c *containerImpl) Child(name string) Node {
 					// index out of bounds
 					return nil
 				}
-				return l.Items()[index]
+				return l.Get(index)
 			} else {
 				// not a list
 				return nil

--- a/dom/list.go
+++ b/dom/list.go
@@ -33,6 +33,10 @@ func (l *listImpl) IsList() bool {
 	return true
 }
 
+func (l *listImpl) Get(index int) Node {
+	return l.items[index]
+}
+
 func (l *listImpl) Items() []Node {
 	c := make([]Node, l.Size())
 	copy(c, l.items)

--- a/dom/list_test.go
+++ b/dom/list_test.go
@@ -43,8 +43,8 @@ func TestList(t *testing.T) {
 	assert.False(t, l.IsLeaf())
 	assert.True(t, l.IsList())
 	assert.Equal(t, 3, l.Size())
-	assert.Equal(t, 123, l.Items()[2].AsContainer().
-		Child("item3").AsList().Items()[0].AsContainer().
+	assert.Equal(t, 123, l.Get(2).AsContainer().
+		Child("item3").AsList().Get(0).AsContainer().
 		Child("sub").AsLeaf().Value())
 	assert.False(t, l.SameAs(nilLeaf))
 }
@@ -59,8 +59,8 @@ func TestMutateList(t *testing.T) {
 	l.MustSet(0, LeafNode(123))
 	l.MustSet(1, LeafNode("abc"))
 
-	assert.Equal(t, "abc", l.Items()[1].AsLeaf().Value())
-	assert.Equal(t, 123, l.Items()[0].AsLeaf().Value())
+	assert.Equal(t, "abc", l.Get(1).AsLeaf().Value())
+	assert.Equal(t, 123, l.Get(0).AsLeaf().Value())
 	l.Clear()
 	assert.Equal(t, 0, l.Size())
 	l.Set(0, LeafNode(123))
@@ -96,8 +96,9 @@ func TestListClone(t *testing.T) {
 	l := ListNode(LeafNode(1), LeafNode(2))
 	l2 := l.Clone().(List)
 	assert.Equal(t, l2.Size(), l.Size())
-	assert.Equal(t, l2.Items()[0], l.Items()[0])
-	assert.Equal(t, l2.Items()[1], l.Items()[1])
+	assert.Equal(t, l2.Get(0), l.Get(0))
+	assert.Equal(t, l2.Get(1), l.Get(1))
+	assert.True(t, l2.Equals(l))
 }
 
 func TestListAsSlice(t *testing.T) {

--- a/dom/merge.go
+++ b/dom/merge.go
@@ -46,10 +46,10 @@ type merger struct {
 func mergeListsAppend(l1, l2 List) List {
 	l := initListBuilder()
 	for i := 0; i < l1.Size(); i++ {
-		l.Append(l1.Items()[i])
+		l.Append(l1.Get(i))
 	}
 	for i := 0; i < l2.Size(); i++ {
-		l.Append(l2.Items()[i])
+		l.Append(l2.Get(i))
 	}
 	return l
 }
@@ -64,8 +64,8 @@ func (mg *merger) mergeListsMeld(l1, l2 List) List {
 		l.Append(nilLeaf)
 	}
 	for i := 0; i < minLen; i++ {
-		n1 := l1.Items()[i]
-		n2 := l2.Items()[i]
+		n1 := l1.Get(i)
+		n2 := l2.Get(i)
 		if n1.IsContainer() && n2.IsContainer() {
 			l.Set(uint(i), mg.mergeContainers(n1.AsContainer(), n2.AsContainer()))
 		} else if n1.IsList() && n2.IsList() {

--- a/dom/merge_test.go
+++ b/dom/merge_test.go
@@ -42,7 +42,7 @@ func TestMergeLists(t *testing.T) {
 		ListNode(ListNode()).(ListBuilder),
 	)
 	assert.Equal(t, 1, l.Size())
-	assert.Equal(t, 2, l.Items()[0].(List).Size())
+	assert.Equal(t, 2, l.Get(0).(List).Size())
 }
 
 func TestMergeListsAppend(t *testing.T) {
@@ -58,9 +58,9 @@ func TestMergeListsAppend(t *testing.T) {
 		),
 	)
 	assert.Equal(t, 3, l.Size())
-	assert.Equal(t, 123, l.Items()[0].AsLeaf().Value())
-	assert.Equal(t, 456, l.Items()[1].AsLeaf().Value())
-	assert.Equal(t, 789, l.Items()[2].AsLeaf().Value())
+	assert.Equal(t, 123, l.Get(0).AsLeaf().Value())
+	assert.Equal(t, 456, l.Get(1).AsLeaf().Value())
+	assert.Equal(t, 789, l.Get(2).AsLeaf().Value())
 }
 
 func TestMergeContainerFromTwoLists(t *testing.T) {

--- a/dom/overlay.go
+++ b/dom/overlay.go
@@ -109,7 +109,7 @@ func ensurePath(node ContainerBuilder, pc []string) ContainerBuilder {
 	for _, component := range pc {
 		if listPathRe.MatchString(component) {
 			list, index, _ := ensureList(component, node)
-			if list.Items()[int(index)] == nilLeaf {
+			if list.Get(int(index)) == nilLeaf {
 				c := initContainerBuilder()
 				list.Set(index, c)
 				node = c
@@ -180,7 +180,7 @@ func hasValue(n Node) bool {
 func firstValidListItem(idx int, lists ...List) Node {
 	for _, list := range lists {
 		if list.Size() > idx {
-			return list.Items()[idx]
+			return list.Get(idx)
 		}
 	}
 	return nilLeaf

--- a/dom/path_ops.go
+++ b/dom/path_ops.go
@@ -38,7 +38,7 @@ func applyToContainer(tgt ContainerBuilder, c path.Component, addList bool) Node
 func applyToList(tgt ListBuilder, c path.Component, addList bool) Node {
 	var x Node
 	if tgt.Size() > c.NumericValue() {
-		x = tgt.Items()[c.NumericValue()]
+		x = tgt.Get(c.NumericValue())
 	} else {
 		if addList {
 			x = ListNode()
@@ -136,7 +136,7 @@ func getFromNode(sourceNode Node, at path.Path) Node {
 	src = sourceNode
 	for _, pc := range at.Components() {
 		if pc.IsNumeric() {
-			src = src.AsList().Items()[pc.NumericValue()]
+			src = src.AsList().Get(pc.NumericValue())
 		} else {
 			src = src.AsContainer().Child(pc.Value())
 		}

--- a/dom/path_ops_test.go
+++ b/dom/path_ops_test.go
@@ -76,9 +76,9 @@ func TestApplyToWithEmptyPath(t *testing.T) {
 
 func TestRemoveChild(t *testing.T) {
 	lb := ListNode(LeafNode(1), LeafNode(2), LeafNode(3))
-	assert.Equal(t, 2, lb.Items()[1].AsLeaf().Value())
+	assert.Equal(t, 2, lb.Get(1).AsLeaf().Value())
 	removeChild(lb, path.NewBuilder().Append(path.Numeric(1)).Build().Last())
-	assert.Nil(t, lb.Items()[1])
+	assert.Nil(t, lb.Get(1))
 
 	assert.Len(t, lb.Items(), 3)
 	// this is effectively no-op, but proves that out of bound extends

--- a/dom/types.go
+++ b/dom/types.go
@@ -137,6 +137,8 @@ type Leaf interface {
 // List is collection of Nodes
 type List interface {
 	Node
+	// Get gets element at given index. Panics if value is out of bounds.
+	Get(int) Node
 	// Size returns current count of items in this list
 	Size() int
 	// Items returns copy of slice of all nodes in this list

--- a/fluent/morpher_test.go
+++ b/fluent/morpher_test.go
@@ -42,7 +42,7 @@ func TestMorpherCopyMerge(t *testing.T) {
 			return len(pc) > 1 && pc[1].NumericValue() != 2
 		}))).Result()
 
-	assert.Equal(t, "str leaf", res.Child("root").AsList().Items()[0].AsLeaf().Value())
+	assert.Equal(t, "str leaf", res.Child("root").AsList().Get(0).AsLeaf().Value())
 	assert.Equal(t, 2, len(res.Child("root").AsList().Items()))
 }
 

--- a/patch/path.go
+++ b/patch/path.go
@@ -151,7 +151,7 @@ func (p Path) Eval(target dom.Container) (dom.NodeList, dom.Node) {
 			if idx, isIndex := ps.IsNumeric(); isIndex {
 				l := curr.(dom.List)
 				if len(l.Items()) > idx {
-					curr = l.Items()[idx]
+					curr = l.Get(idx)
 					res = append(res, curr)
 				} else {
 					// list index out of bounds

--- a/patch/utils_test.go
+++ b/patch/utils_test.go
@@ -28,8 +28,8 @@ func TestRemoveListItem(t *testing.T) {
 	assert.Equal(t, 3, l.Size())
 	removeListItem(l, 1)
 	assert.Equal(t, 2, l.Size())
-	assert.Equal(t, 1, l.Items()[0].(dom.Leaf).Value())
-	assert.Equal(t, 3, l.Items()[1].(dom.Leaf).Value())
+	assert.Equal(t, 1, l.Get(0).AsLeaf().Value())
+	assert.Equal(t, 3, l.Get(1).AsLeaf().Value())
 }
 
 func TestInsertListItem(t *testing.T) {
@@ -37,5 +37,5 @@ func TestInsertListItem(t *testing.T) {
 	assert.Equal(t, 3, l.Size())
 	insertListItem(l, 3, dom.LeafNode("d"))
 	assert.Equal(t, 4, l.Size())
-	assert.Equal(t, "d", l.Items()[3].(dom.Leaf).Value())
+	assert.Equal(t, "d", l.Get(3).(dom.Leaf).Value())
 }


### PR DESCRIPTION
Calling `list.Items()[index]` is inefficient.

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
