### PR TITLE
⚰️  DOM: Remove deprecated RemoveAt() method from ContainerBuilder

### DIFF
--- a/dom/container.go
+++ b/dom/container.go
@@ -298,8 +298,6 @@ func (c *containerBuilderImpl) ancestorOf(path string, create bool) (ContainerBu
 		if x == nil || !x.IsContainer() {
 			if create {
 				node = c.addChild(node, p)
-			} else {
-				return nil, ""
 			}
 		} else {
 			node = x.(ContainerBuilder)
@@ -311,13 +309,6 @@ func (c *containerBuilderImpl) ancestorOf(path string, create bool) (ContainerBu
 func (c *containerBuilderImpl) AddValueAt(path string, value Node) ContainerBuilder {
 	node, p := c.ancestorOf(path, true)
 	node.AddValue(p, value)
-	return c
-}
-
-func (c *containerBuilderImpl) RemoveAt(path string) ContainerBuilder {
-	if node, p := c.ancestorOf(path, false); node != nil {
-		node.Remove(p)
-	}
 	return c
 }
 

--- a/dom/container_test.go
+++ b/dom/container_test.go
@@ -149,18 +149,6 @@ func TestFromMap(t *testing.T) {
 	assert.Equal(t, "abc", c.Child("test1.test2").AsLeaf().Value())
 }
 
-func TestRemoveAt(t *testing.T) {
-	c := DecodeAnyToNode(map[string]interface{}{
-		"test2":  "abc",
-		"test22": 123,
-		"testC":  "Hi",
-	}).(ContainerBuilder)
-	c.RemoveAt("non-existing.another")
-	assert.NotNil(t, c.Child("test22"))
-	c.RemoveAt("test22")
-	assert.Nil(t, c.Child("test22"))
-}
-
 func TestAddValueAt(t *testing.T) {
 	c := ContainerNode()
 	c.AddValueAt("test1.test2.test31", LeafNode("abc"))

--- a/dom/types.go
+++ b/dom/types.go
@@ -231,10 +231,6 @@ type ContainerBuilder interface {
 	// AddValueAt adds Node into this Container at given path.
 	// Child nodes are creates as needed.
 	AddValueAt(path string, value Node) ContainerBuilder
-
-	// deprecated, use Delete(path)
-	// RemoveAt removes child Node at given path.
-	RemoveAt(path string) ContainerBuilder
 }
 
 var (


### PR DESCRIPTION
Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
