### PR TITLE
⚰️  DOM: Remove deprecated DefaultNodeEncoderFn

### DIFF
--- a/dom/container_test.go
+++ b/dom/container_test.go
@@ -28,11 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestContainerEncodeDecode(t *testing.T) {
-	x := getTestDoc(t, "doc1")
-	assert.Equal(t, x.AsAny(), DefaultNodeEncoderFn(x))
-}
-
 func TestBuilderFromYamlString(t *testing.T) {
 	doc, err := DecodeReader(strings.NewReader(`
 abc: 123

--- a/dom/types.go
+++ b/dom/types.go
@@ -68,11 +68,6 @@ func DefaultJsonEncoder(w io.Writer, v interface{}) error {
 	return e.Encode(v)
 }
 
-// deprecated, no longer needed as every Node implements AsAny.
-func DefaultNodeEncoderFn(n Container) interface{} {
-	return encodeContainerFn(n)
-}
-
 func DefaultNodeDecoderFn(m map[string]interface{}) Container {
 	cb := *initContainerBuilder()
 	decodeContainerFn(&m, &cb)

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -70,7 +70,7 @@ func dom2gen[T any](c dom.Container) *T {
 		buf bytes.Buffer
 		t   T
 	)
-	panicIfError(yaml.NewEncoder(&buf).Encode(dom.DefaultNodeEncoderFn(c)))
+	panicIfError(yaml.NewEncoder(&buf).Encode(c.AsAny()))
 	panicIfError(yaml.NewDecoder(&buf).Decode(&t))
 	return &t
 }
@@ -111,7 +111,7 @@ func (c *configHelper[T]) Save(file string) ConfigHelper[T] {
 	defer func() {
 		_ = f.Close()
 	}()
-	panicIfError(fep(f, dom.DefaultNodeEncoderFn(c.c)))
+	panicIfError(fep(f, c.c.AsAny()))
 	return c
 }
 


### PR DESCRIPTION
Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
